### PR TITLE
Eliminate two "unused import" warnings and a "feature is now stable" warning

### DIFF
--- a/psx/src/dma/gpu.rs
+++ b/psx/src/dma/gpu.rs
@@ -1,7 +1,7 @@
 use super::{Direction, Step, TransferMode, GPU};
-use crate::gpu::{draw_sync, DMAMode};
+use crate::gpu::DMAMode;
 use crate::hal::dma::{ChannelControl, MemoryAddress, SharedChannelControl};
-use crate::hal::{MutRegister, GP1, GPUSTAT};
+use crate::hal::{MutRegister, GP1};
 
 impl GPU {
     // This works even if `list` is stack allocated because it's blocking.

--- a/psx/src/lib.rs
+++ b/psx/src/lib.rs
@@ -5,7 +5,7 @@
 #![feature(global_asm)]
 #![feature(c_variadic)]
 #![feature(alloc_error_handler)]
-#![feature(panic_info_message, fmt_as_str)]
+#![feature(panic_info_message)]
 // Const features used to increase the potential scope of const testing.
 #![feature(
     const_ptr_offset,


### PR DESCRIPTION
The easiest way to squish these warnings on my end was to edit the code, and then it was easy to make a pull request. The "feature is now stable" warning I got said that the feature became stable in 1.52, but the compiler I have is 1.51, so... not sure how that works. The other two warnings are solid, though.