### PR TITLE
Avoid passing a to-be-printed string directly as the format string argument of printf

### DIFF
--- a/psx/src/bios/tty.rs
+++ b/psx/src/bios/tty.rs
@@ -41,7 +41,7 @@ macro_rules! println {
 
 impl fmt::Write for TTY {
     fn write_str(&mut self, s: &str) -> fmt::Result {
-        s.as_cstr::<_, _, MAX_LEN>(|s| printf!(s));
+        s.as_cstr::<_, _, MAX_LEN>(|s| printf!("%s\0", s));
         Ok(())
     }
 }

--- a/psx/src/panic.rs
+++ b/psx/src/panic.rs
@@ -47,12 +47,12 @@ fn panic(info: &PanicInfo) -> ! {
     match info.location() {
         Some(location) => {
             printf!("Panicked at \0");
-            location.file().as_cstr::<_, _, MAX_LEN>(|s| printf!(s));
+            location.file().as_cstr::<_, _, MAX_LEN>(|s| printf!("%s\0", s));
             printf!(":%d:%d\n\0", location.line(), location.column());
         },
         None => printf!("Panicked at unknown location\n\0"),
     }
-    message(info).as_cstr::<_, _, MAX_LEN>(|s| printf!(s));
+    message(info).as_cstr::<_, _, MAX_LEN>(|s| printf!("%s\0", s));
     printf!("\n\0");
     loop {}
 }


### PR DESCRIPTION
Without this change, if I'm understanding the code correctly, `println!("You are {}% complete!", completion)` might output `"You are 100\0omplete!"`, for example. I haven't tested it myself yet since I'm still trying to fix my whole PSX dev pipeline all at once from first principles on a new platform... But! It builds.