### PR TITLE
Add basic github CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,0 +1,38 @@
+name: Rust
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Provision build environment
+      run: |
+        rustup update nightly
+        rustup component add rust-src --toolchain nightly
+        # Install cargo-psx
+        pushd cargo-psx
+        cargo install --path .
+        popd
+    - name: Build
+      run: |
+        pushd psx
+        # Check that library builds
+        cargo psx build
+        popd
+        # Check that hello world builds
+        pushd examples/hello_world
+        cargo psx build
+        popd


### PR DESCRIPTION
PR #10 pointed out that there's an issue that's probably caused by not namespacing the BIOS libc symbols, so this adds some basic CI to check if things at least build. It'd be nice to add the `psx` crate tests to this, but I'd have to figure that requires a BIOS so github CI would probably not be an option.