### PR TITLE
ci: Build examples

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -50,3 +50,15 @@ jobs:
             | tee bios_stdout &
         sleep 15
         grep "test result: ok. [0-9]* passed; 0 failed" bios_stdout
+        popd
+    - name: Build examples
+      run: |
+        pushd examples
+        for d in */; do
+            if [ $d != "bios/" ]; then
+                pushd $d
+                cargo psx build
+                popd
+            fi
+        done
+        popd

--- a/examples/loader/build.rs
+++ b/examples/loader/build.rs
@@ -15,9 +15,8 @@ fn main() {
             "psx",
             "build",
             "--lto",
-            "--alloc",
-            "--cargo-args",
-            "features psx/loadable_exe",
+            "--features",
+            "psx/loadable_exe,psx/heap",
             "--load-offset=524288",
             "--stack-pointer=0",
         ])


### PR DESCRIPTION
Running examples with xvfb is kinda annoying so I'm leaving running the examples to a separate PR and just building examples in this one. Closes #21.