### PR TITLE
bios: Use fstrings in println

### DIFF
--- a/examples/bios/src/boot.rs
+++ b/examples/bios/src/boot.rs
@@ -89,10 +89,8 @@ fn init_ram(cs: &mut CriticalSection) {
         let dst = (KSEG0 + 0x100) as *mut u32;
         let src = &__data_start as *const u32;
         println!(
-            "Copying {} bytes from {:p} to {:p} to initialize .data",
+            "Copying {} bytes from {src:p} to {dst:p} to initialize .data",
             len * 4,
-            src,
-            dst
         );
         volatile_copy_nonoverlapping_memory(dst, src, len);
 
@@ -101,10 +99,8 @@ fn init_ram(cs: &mut CriticalSection) {
         let bss_len = (bss_end - bss_start) / 4;
         let bss_dst = &mut __bss_start as *mut u32;
         println!(
-            "Zeroing out {} bytes from {:x} to {:x} to initialize .bss",
+            "Zeroing out {} bytes from {bss_start:x} to {bss_end:x} to initialize .bss",
             bss_len * 4,
-            bss_start,
-            bss_end
         );
         volatile_set_memory(bss_dst, 0, bss_len);
     }
@@ -114,7 +110,7 @@ fn init_ram(cs: &mut CriticalSection) {
     let heap = HEAP.borrow(cs);
     let ptr = HEAP_MEM.borrow(cs).as_mut_ptr().cast();
     let len = HEAP_MEM.borrow(cs).len() * size_of::<u32>();
-    println!("Initializing the heap at {:p} ({} bytes)", ptr, len);
+    println!("Initializing the heap at {ptr:p} ({len} bytes)");
     unsafe {
         heap.init(ptr, len);
     }

--- a/examples/bios/src/main.rs
+++ b/examples/bios/src/main.rs
@@ -26,8 +26,8 @@ fn main() {
     println!("Starting main BIOS function");
     let version_str = get_system_version();
     let bios_date = get_system_date();
-    println!("{:?}", version_str);
-    println!("{:x?}", bios_date);
+    println!("{version_str:?}");
+    println!("{bios_date:x?}");
 
     cop0::Status::new()
         .enable_interrupts()


### PR DESCRIPTION
This is a pretty minimal change I had locally which I'm mainly using to test CI.