### PR TITLE
psx: Updates to panic info for 1.81.0 (~Jun 2024)

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 </p>
 
 This is a basic SDK to run custom Rust code on a PlayStation 1. It works with
-Rust nightly version equal to or later than `2022-11-04`. Use
+Rust nightly version equal to or later than `2024-08-23`. Use
 [`rustup`](https://www.rust-lang.org/) to install the rust toolchain as follows.
 
 ```

--- a/psx/src/lib.rs
+++ b/psx/src/lib.rs
@@ -40,8 +40,6 @@
 )]
 // Used to implement `ImplsAsCStr` trait
 #![feature(min_specialization)]
-// For the panic handler
-#![feature(panic_info_message)]
 // For global_asm! on MIPS
 #![feature(asm_experimental_arch)]
 // For `__start`'s return type

--- a/psx/src/panic.rs
+++ b/psx/src/panic.rs
@@ -44,9 +44,6 @@ fn min_panic(info: &core::panic::PanicInfo) {
             println!("Panicked at unknown location")
         },
     }
-    if let Some(msg) = info.message() {
-        println!("{}", msg)
-    }
 }
 
 fn normal_panic(info: &core::panic::PanicInfo) {
@@ -69,9 +66,6 @@ fn normal_panic(info: &core::panic::PanicInfo) {
             None => {
                 dprintln!(txt, "Panicked at unknown location");
             },
-        }
-        if let Some(msg) = info.message() {
-            dprintln!(txt, "{}", msg);
         }
         fb.draw_sync();
         fb.wait_vblank();

--- a/psx/src/panic.rs
+++ b/psx/src/panic.rs
@@ -44,6 +44,7 @@ fn min_panic(info: &core::panic::PanicInfo) {
             println!("Panicked at unknown location")
         },
     }
+    println!("{}", info.message());
 }
 
 fn normal_panic(info: &core::panic::PanicInfo) {
@@ -67,6 +68,7 @@ fn normal_panic(info: &core::panic::PanicInfo) {
                 dprintln!(txt, "Panicked at unknown location");
             },
         }
+        dprintln!(txt, "{}", info.message());
         fb.draw_sync();
         fb.wait_vblank();
         fb.swap();


### PR DESCRIPTION
`panic_info_message` has been stable since 1.81.0
 see
https://stackoverflow.com/questions/78900800/trying-to-access-the-panic-info-message-causes-a-mismatched-types-error
 and
https://github.com/rust-lang/rust/pull/115974

This PR 
* removes the `if let`s following the advice from the stackoverflow post above
* removes the feature attribute for `panic_info_message` now that is is stable (since 1.81.0)

I was using the recent
```
rustc 1.82.0-nightly (4074d4902 2024-08-23)
```

Attempting `cargo psx run` of the Ferris example gave me errors like:

```
error[E0308]: mismatched types
  --> PATH_REDACTED/src/panic.rs:19:16
   |
19 |         if let Some(msg) = info.message() {
   |                ^^^^^^^^^   -------------- this expression has type `PanicMessage<'_>`
   |                |
   |                expected `PanicMessage<'_>`, found `Option<_>`
   |
   = note: expected struct `PanicMessage<'_>`
                found enum `Option<_>`

```

and also

```
warning: the feature `panic_info_message` has been stable since 1.81.0 and no longer requires an attribute to enable
  -->  PATH_REDACTED/psx-sdk-rs/psx/src/lib.rs:44:12
   |
44 | #![feature(panic_info_message)]
   |            ^^^^^^^^^^^^^^^^^^
   |
   = note: `#[warn(stable_features)]` on by default
```