### PR TITLE
Enable all Framebuffer NTSC / PAL screen modes

### DIFF
--- a/psx/src/framebuffer.rs
+++ b/psx/src/framebuffer.rs
@@ -74,10 +74,14 @@ impl Framebuffer {
             ],
             swapped: false,
         };
+        let interlace = match res.1 {
+            480 | 512 => true,
+            _ => false
+        };
         GP1::skip_load()
             .reset_gpu()
             .dma_mode(Some(DMAMode::GP0))
-            .display_mode(res, video_mode, Depth::Bits15, false)?
+            .display_mode(res, video_mode, Depth::Bits15, interlace)?
             .enable_display(true);
         fb.irq_mask.enable_irq(IRQ::Vblank).store();
         //fb.wait_vblank();

--- a/psx/src/gpu/mod.rs
+++ b/psx/src/gpu/mod.rs
@@ -244,7 +244,7 @@ impl DrawEnv {
         let size = Vertex::new(size);
         let bg_color = bg_color.unwrap_or(colors::BLACK);
         let upper_left = PackedVertex::try_from(offset)?;
-        let lower_right = PackedVertex::try_from(offset + size)?;
+        let lower_right = PackedVertex::try_from(offset + size - Vertex::new((1, 1)))?;
         Ok(DrawEnv {
             texpage_cmd: 0xE1,
             upper_left_cmd: 0xE3,

--- a/psx/src/gpu/mod.rs
+++ b/psx/src/gpu/mod.rs
@@ -191,7 +191,6 @@ impl DispEnv {
         offset: (i16, i16), size: (i16, i16), video_mode: VideoMode,
     ) -> Result<Self, VertexError> {
         let offset = Vertex::new(offset);
-        let size = Vertex::new(size);
         let offset = PackedVertex::try_from(offset)?;
         let (center, range) = if video_mode == VideoMode::NTSC {
             (0x88, 240)
@@ -199,7 +198,7 @@ impl DispEnv {
             (0xA3, 256)
         };
         let ntsc_vrange = Vertex(center - (range / 2), center + (range / 2));
-        let hrange = Vertex(0x260, 0x260 + (size.0 * 8));
+        let hrange = Vertex(0x260, 0x260 + (320 * 8));
 
         let horizontal_range = PackedVertex::try_from(hrange)?;
         let vertical_range = PackedVertex::try_from(ntsc_vrange)?;

--- a/psx/src/hw/gpu/gp1.rs
+++ b/psx/src/hw/gpu/gp1.rs
@@ -59,8 +59,9 @@ impl GP1 {
         self
     }
 
-    /// The x resolution is restricted to 256, 320, 512, 640 or 368. The y
-    /// resolution is restricted to 240 or 480.
+    /// The x resolution is restricted to 256, 320, 512, 640 or 368.
+    /// The y resolution is restricted to 240 or 480 for NTSC,
+    /// 256 or 512 for PAL.
     pub fn display_mode(
         &mut self, res: (i16, i16), mode: VideoMode, depth: Depth, interlace: bool,
     ) -> Result<&mut Self, VertexError> {
@@ -72,9 +73,9 @@ impl GP1 {
             368 => 1 << 6,
             _ => return Err(VertexError::InvalidX),
         };
-        let vres = match res.1 {
-            240 => 0,
-            480 => 1,
+        let vres = match (mode, res.1) {
+            (VideoMode::NTSC, 240) | (VideoMode::PAL, 256) => 0,
+            (VideoMode::NTSC, 480) | (VideoMode::PAL, 512) => 1,
             _ => return Err(VertexError::InvalidY),
         };
         let settings =


### PR DESCRIPTION
This PR:
* Fixes NTSC 256x240 mode, which previously displayed as 205x240 (in Mednafen emulator at least)
* Enables NTSC 512x240 and NTSC 640x240 modes, which previous paniced on InvalidY from an over-PackedVector
* Autoselects appropriate interlace mode based on Framebuffer height for both PAL and NTSC, previously 480 and 512 heights displayed at the non-interlaced resolutions (240 and 256)
* Enables all PAL mode Framebuffers, by adding them as valid Vres, and fixing an off-by-one error on `lower_right` corners which does not cause errors in NTSC modes, but does for PAL modes in the 512 height VRAM
* Changes the horizontal width 368 to 384. This is a strange mode, it seems theoretical? I was looking at Yaroze documentation which consistently claims 384 is the correct value, happy to revert this if there is a reason why 368 is correct?

Unfortunately I still don't quite understand the range of values that can be passed to
[GP1(06h) - Horizontal Display range (on Screen)](https://problemkaputt.de/psx-spx.htm#gpudisplaycontrolcommandsgp1), or what the units are.

I _think_ the exact values are (mostly?) independent of the desired display resolution and have more to do with the analog video output signal and the range of analog display devices (CRTs), and depend on VSYNC and HSYNC timings of PAL/NTSC signals and so on...  The documentation I have seen isn't very clear, and all explanations I have found make sense for NTSC 320x240, but it's difficult to apply to other modes. I could also be missing something.

Supporting my theory that the value is independent: https://github.com/Lameguy64/PSn00bSDK/blob/702bb601fb5712e2ae962a34b89204c646fe98f5/libpsn00b/psxgpu/env.c#L149 `SetDefDispEnv` appears to set all the _screen_ values to 0 regardless of the supplied `x, y, w, h`, and that causes identical  values to what `psx-sdk-rs` previously calculated for 320x240 to be sent to  GP1(06h) -- so the values are effectively hard coded. I have not disassembled PsyQ to figure out what it uses.

The current `psx-sdk-rs`  calculated values for widths 512 and 640 overflow the PackedVertex, and panic with `InvalidY`, so the current formula is not correct for those resolutions. The calculated value for 256 x 240 also truncated the displayed screen to 205x240, so the formula also seems incorrect for lower widths too. This PR's hardcoded value gives expected results for all resolutions (... except 384, but maybe that is expected, or another PSX issue?)


I have currently only tested this in one emulator (Mednafen); testing non-interlaced and interlaced double buffering modes for NTSC and PAL with text display and PolyF4 drawing.

I should be able to test the PAL modes on a real PSX (hopefully GP1(06h) won't damage my stuff!)

Sorry for the description verbosity, there are only a few lines of code changed here, but testing all ~20 mode combinations has taken some time to research and write test examples for. I hope the problems I'm fixing are clear enough!

If anyone has any comments or tips for testing, please comment below!

tagging @Kapouett because you said you were interested in PAL modes (a while ago now!)
@ayrtonm, I'd love to get your feedback on this, you've probably read all the same slightly unclear docs I did.

### Testing:
non-interlaced modes, tested in emulator (Mednafen)
Vertically stacked disp/draw: `Framebuffer::new((0, 0), (0, y), (x, y), VideoMode::NTSC) `

<google-sheets-html-origin><style type="text/css"><!--td {border: 1px solid #cccccc;}br {mso-data-placement:same-cell;}--></style>

mode (NTSC) | BEFORE | AFTER
-- | -- | --
NTSC 256 x 240 | Truncated width, 205 pixels wide, 240 high | WORKING (256 x 240)
NTSC 320 x 240 | WORKING | WORKING
NTSC 512 x 240 | InvalidY @ psx/gpu/vertex PackedVertex::const_try_from() via horizontal_range() | WORKING
NTSC 640 x 240 | InvalidY @ psx/gpu/vertex PackedVertex::const_try_from() via horizontal_range() | WORKING
NTSC 368 x 240 | WORKING (368 wdith) | InvalidX @ psx/hw/gpu/gp1 display_mode()
NTSC 384 x 240 | InvalidX @ psx/hw/gpu/gp1 display_mode() | Truncated width = 364 pixels displayed on screen, (disp and draw are 384)
**mode (PAL)** | **BEFORE** | **AFTER**
PAL 256 x 256 | InvalidY @ psx/gpu/vertex PackedVertex::const_try_from() via psx/gpu/mod lower_right: PackedVertex<3, 10, 9> | WORKING, 256x256
PAL 320 x 256 | InvalidY @ psx/gpu/vertex PackedVertex::const_try_from() via psx/gpu/mod lower_right: PackedVertex<3, 10, 9> | WORKING, 320x256
PAL 512 x 256 | InvalidY @ psx/gpu/vertex PackedVertex::const_try_from() via psx/gpu/mod lower_right: PackedVertex<3, 10, 9> | WORKING, 512x256
PAL 640 x 256 | InvalidY @ psx/gpu/vertex PackedVertex::const_try_from() via psx/gpu/mod lower_right: PackedVertex<3, 10, 9> | WORKING, 640x256
PAL 368 x 256 | InvalidY @ psx/gpu/vertex PackedVertex::const_try_from() via psx/gpu/mod lower_right: PackedVertex<3, 10, 9> | InvalidX @ psx/hw/gpu/gp1 display_mode()
PAL 384 x 256 | InvalidX @ psx/hw/gpu/gp1 display_mode() | Truncated width = 364 pixels displayed on screen, (disp and draw are 384)

It looks like maybe I should revert the 368 -> 384 change for now as it seemed more sensible before.

I also tested Interlaced Display / Draw Framebuffers (side-by-side). They all use the non-interlaced screen height for display since the interlaced mode flag is currently hardcoded. ~I should be able to fix this too.~ *UPDATE:* Interlaced modes are now enabled in 221c2c6d177391af10aa16041a9c5ebe4884f83b 

**TODO later, not in this PR**:
* Looks like pixel mode is also hardcoded to Depth::Bits15. Not sure how to select Depth::Bits24, "24-bit true-color mode" https://github.com/ayrtonm/psx-sdk-rs/blob/fe4e0ecccae8123c1bec68071fda53e4cb15dc19/psx/src/framebuffer.rs#L80
* Interlaced PAL (screen height 512) doesn't have the background fill.
	* `bg_color_cmd: 0x02`, - Fill Rectangle in VRAM, 3rd arg:  `Width+Height      (YsizXsizh)  ;Xsiz counted in halfwords, steps of 10h` , via https://problemkaputt.de/psx-spx.htm#gpumemorytransfercommands
	* this does _not_ have an off-by-one error: it really is the Y size (not lower right corner), but its max value is 0x1ff (511) so it cannot fully fill a 512 high region, the best it can do is fill 511 and leave one pixel row blank.
	* Suggested FIX/workaround: in psx/src/gpu/mod.rs accept all values for bg_size, unless bg_size.1 == 512, then change it to 511,  or  `min(bg_size.1, 511)` . This seems a problem with the PSX GPU command, not the sdk.


Also, I don't know why the last test failed on CI -- it appears unrelated to my changes, and I don't get the error locally.