### PR TITLE
examples: Increase sys_heap size for two examples

### DIFF
--- a/examples/donut/src/main.rs
+++ b/examples/donut/src/main.rs
@@ -10,7 +10,7 @@ use psx::math::{f16, rotate_x, rotate_y, rotate_z};
 use psx::sys::rng::Rng;
 use psx::{dma, println, Framebuffer};
 
-psx::sys_heap!(4 kb);
+psx::sys_heap!(5 KB);
 
 #[no_mangle]
 fn main() {

--- a/examples/monkey/src/main.rs
+++ b/examples/monkey/src/main.rs
@@ -11,7 +11,7 @@ use psx::math::{f16, rotate_x, rotate_y, rotate_z, Rad};
 use psx::sys::rng::Rng;
 use psx::{dma, Framebuffer};
 
-psx::sys_heap!(4 kb);
+psx::sys_heap!(7 KB);
 
 #[derive(Debug, Clone, Copy)]
 enum Face {


### PR DESCRIPTION
closes #36

This increases the `sys_heap` size to a KB rounded minimum to prevent out of memory errors on the monkey and donut examples.

I observe exactly the same sizes and error messages as reported in #36 

In my comment on that issue I mistakenly thought the KB size had to be a multiple of 4, I realise now that it's only the _byte_ size that must be a multiple of 4. I'm using the smallest KB sizes that work, which are in line with the error output reported sizes

7000 -> 7KB for monkey
4608 -> 5KB for donut

I've changed the capitalisation `kb` -> `KB` to match the [docs](https://docs.rs/psx/0.1.6/psx/macro.sys_heap.html).

I've also not looked into whether 4KB _should_ be enough on some BIOSes, and can't remember if it ever worked with 4KB for me. It seems like a small size increase to make the examples work under more configurations for demo purposes. 