### PR TITLE
Update to Nightly 2025-05-23

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 </p>
 
 This is a basic SDK to run custom Rust code on a PlayStation 1. It works with
-Rust nightly version equal to `2024-12-21`. Newer nightly versions may or may
+Rust nightly version equal to `2025-05-23`. Newer nightly versions may or may
 not work depending on changes to unstable features. The
 [github repo](https://github.com/ayrtonm/psx-sdk-rs) may be more up-to-date
 with unstable feature usage so consider using a
@@ -14,7 +14,7 @@ to use the newest nightly versions. Use [`rustup`](https://www.rust-lang.org/)
 to install the rust toolchain as follows.
 
 ```
-rustup update nightly-2024-12-21
+rustup update nightly-2025-05-23
 rustup component add rust-src --toolchain nightly
 ```
 

--- a/psx/.cargo/config.toml
+++ b/psx/.cargo/config.toml
@@ -1,2 +1,10 @@
+[build]
+target = ["mipsel-sony-psx"]
+
 [target.mipsel-sony-psx]
 runner = "mednafen"
+rustflags = ["-Clink-arg=-Tpsexe.ld", "-Clink-arg=--oformat=binary"]
+
+[unstable]
+build-std = ["core", "alloc"]
+build-std-features = ["compiler-builtins-mem"]

--- a/psx/Cargo.toml
+++ b/psx/Cargo.toml
@@ -39,3 +39,8 @@ loadable_exe = []
 custom_oom = []
 heap = ["dep:linked_list_allocator"]
 nightlier = []
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = [
+    'cfg(feature,values("nonexistent_feature"))',
+] }

--- a/psx/build.rs
+++ b/psx/build.rs
@@ -2,12 +2,12 @@ use std::path::PathBuf;
 use std::{env, fs};
 
 fn main() {
-    const LINKER_SCRIPT: &'static str = "psexe.ld";
-    const LOAD_OFFSET: &'static str = "PSX_LOAD_OFFSET";
-    const STACK_POINTER: &'static str = "PSX_STACK_POINTER";
-    println!("cargo:rerun-if-changed={}", LINKER_SCRIPT);
-    println!("cargo:rerun-if-env-changed={}", LOAD_OFFSET);
-    println!("cargo:rerun-if-env-changed={}", STACK_POINTER);
+    const LINKER_SCRIPT: &str = "psexe.ld";
+    const LOAD_OFFSET: &str = "PSX_LOAD_OFFSET";
+    const STACK_POINTER: &str = "PSX_STACK_POINTER";
+    println!("cargo:rerun-if-changed={LINKER_SCRIPT}");
+    println!("cargo:rerun-if-env-changed={LOAD_OFFSET}");
+    println!("cargo:rerun-if-env-changed={STACK_POINTER}");
 
     let out = &PathBuf::from(env::var_os("OUT_DIR").unwrap());
     println!("cargo:rustc-link-search={}", out.display());
@@ -15,12 +15,12 @@ fn main() {
     // Read the template ld script and add a load offset is requested
     let mut ld_script = include_str!("psexe.ld").to_string();
     if let Ok(offset) = env::var(LOAD_OFFSET) {
-        ld_script = ld_script.replace("LOAD_OFFSET = 0", &format!("LOAD_OFFSET = {}", offset));
+        ld_script = ld_script.replace("LOAD_OFFSET = 0", &format!("LOAD_OFFSET = {offset}"));
     }
     if let Ok(sp) = env::var(STACK_POINTER) {
         ld_script = ld_script.replace(
             "STACK_INIT = RAM_BASE + 0x001FFF00",
-            &format!("STACK_INIT = {}", sp),
+            &format!("STACK_INIT = {sp}"),
         );
     }
 

--- a/psx/rust-toolchain.toml
+++ b/psx/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "nightly-2025-05-23"
+components = ["rustfmt", "clippy", "rust-src"]

--- a/psx/src/dma.rs
+++ b/psx/src/dma.rs
@@ -251,3 +251,9 @@ impl<A: MemoryAddress, B: BlockControl, C: ChannelControl> Channel<A, B, C> {
         self.send_list_and(list, || ())
     }
 }
+
+impl<A: MemoryAddress, B: BlockControl, C: ChannelControl> Default for Channel<A, B, C> {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/psx/src/format/obj.rs
+++ b/psx/src/format/obj.rs
@@ -183,27 +183,33 @@ impl<
     /// Creates an array by calling `f` for each face.
     pub fn for_each_face<T, F>(&self, mut f: F) -> [T; FACES]
     where F: FnMut() -> T {
-        let mut res = MaybeUninit::uninit_array();
-        for n in 0..QUADS + TRIS {
-            res[n].write(f());
-        }
+        let mut res = [const { MaybeUninit::uninit() }; FACES];
+
+        res[..QUADS + TRIS].write_with(|_| f());
+
+        // TODO: FACES must equal QUADS + TRIS for the below to be safe.
+        // Should this be asserted, or compile-time enforced?
+
         unsafe { MaybeUninit::array_assume_init(res) }
     }
 
     /// Creates an array by applying `f_quad` to each quad and `f_tri` to each
     /// tri.
-    pub fn map_faces<T, F, G>(&self, mut f_quad: F, mut f_tri: G) -> [T; FACES]
+    pub fn map_faces<T, F, G>(&self, f_quad: F, f_tri: G) -> [T; FACES]
     where
         F: FnMut([u16; 4]) -> T,
         G: FnMut([u16; 3]) -> T, {
-        let mut res = MaybeUninit::uninit_array();
-        for n in 0..QUADS + TRIS {
-            if n < QUADS {
-                res[n].write(f_quad(self.quads[n]));
-            } else {
-                res[n].write(f_tri(self.tris[n - QUADS]));
-            }
-        }
+        let mut res = [const { MaybeUninit::uninit() }; FACES];
+
+        let quads = self.quads.iter().copied().map(f_quad);
+        let tris = self.tris.iter().copied().map(f_tri);
+
+        let (_init, uninit) = res.write_iter(quads);
+        let (_init, _uninit) = uninit.write_iter(tris);
+
+        // TODO: _uninit must be empty for the below to be safe.
+        // Should this be asserted, or compile-time enforced?
+
         unsafe { MaybeUninit::array_assume_init(res) }
     }
 

--- a/psx/src/format/tim.rs
+++ b/psx/src/format/tim.rs
@@ -13,7 +13,7 @@ macro_rules! include_tim {
         use $crate::format::tim::{Bitmap, MAGIC, TIM};
         use $crate::gpu::{Bpp, Clut, TexPage, Vertex};
 
-        const TIM_SIZE: usize = (file_size!($file) + 3) / 4;
+        const TIM_SIZE: usize = (file_size!($file)).div_ceil(4);
         const TIM_DATA: [u32; TIM_SIZE] = {
             let data = *include_bytes!($file);
             if data.len() % 4 != 0 {
@@ -106,7 +106,9 @@ macro_rules! include_tim {
         };
         TIM::<BMP_LEN, CLUT_LEN> {
             bpp: BPP,
+            #[expect(static_mut_refs)]
             bmp: unsafe { &mut BMP },
+            #[expect(static_mut_refs)]
             clut: unsafe { &mut CLUT },
         }
     }};

--- a/psx/src/framebuffer.rs
+++ b/psx/src/framebuffer.rs
@@ -74,10 +74,7 @@ impl Framebuffer {
             ],
             swapped: false,
         };
-        let interlace = match res.1 {
-            480 | 512 => true,
-            _ => false
-        };
+        let interlace = matches!(res.1, 480 | 512);
         GP1::skip_load()
             .reset_gpu()
             .dma_mode(Some(DMAMode::GP0))

--- a/psx/src/gpu/mod.rs
+++ b/psx/src/gpu/mod.rs
@@ -164,7 +164,6 @@ pub struct PhysAddr([u8; 3]);
 /// but the `inline_const` feature can simplify this as follows.
 ///
 /// ```rust
-/// #![feature(inline_const)]
 /// let array = [const { Packet::new(T::new()) }; N]
 /// ```
 #[repr(C, align(4))]
@@ -187,6 +186,7 @@ pub struct DispEnv {
 impl DispEnv {
     /// Creates a new display buffer at `offset` in VRAM with the specified
     /// `size`.
+    #[expect(unused_variables)]
     pub fn new(
         offset: (i16, i16), size: (i16, i16), video_mode: VideoMode,
     ) -> Result<Self, VertexError> {

--- a/psx/src/gpu/packet.rs
+++ b/psx/src/gpu/packet.rs
@@ -140,10 +140,16 @@ impl<T> Packet<T> {
 ///
 /// Note the packets are linked from first to last.
 pub fn ordering_table<T>(list: &mut [u32]) -> &mut [Packet<()>] {
-    let n = list.len();
+    // Compile-time check to ensure the below transmute is valid
+    const _: () = {
+        if size_of::<u32>() != size_of::<Packet<()>>() {
+            panic!()
+        }
+    };
+
     let packets = unsafe { transmute::<&mut [u32], &mut [Packet<()>]>(list) };
-    for i in 0..n {
-        packets[i].size = 0;
+    for packet in packets {
+        packet.size = 0;
     }
     link_list(packets);
     unsafe { slice::from_raw_parts_mut(list.as_mut_ptr() as *mut Packet<()>, n) }

--- a/psx/src/gpu/primitives/macros.rs
+++ b/psx/src/gpu/primitives/macros.rs
@@ -15,12 +15,17 @@ macro_rules! impl_primitive {
             /// Creates a new primitive
             pub const fn new() -> Self {
                 let buf = [0u8; size_of::<Self>()];
-                let mut primitive = unsafe { transmute::<_, Self>(buf) };
+                let mut primitive = unsafe { transmute::<[u8; size_of::<Self>()], Self>(buf) };
                 primitive.cmd = $cmd;
                 primitive
             }
         }
         impl GP0Command for $name {}
+        impl Default for $name {
+            fn default() -> Self {
+                Self::new()
+            }
+        }
     };
     ($name:ident < N > , $cmd:expr) => {
         impl<const N: usize> $name<N> {

--- a/psx/src/gpu/vertex.rs
+++ b/psx/src/gpu/vertex.rs
@@ -103,9 +103,7 @@ impl<const N: usize, const X: usize, const Y: usize> TryFrom<Vertex> for PackedV
 impl<const N: usize, const X: usize, const Y: usize> From<PackedVertex<N, X, Y>> for Vertex {
     fn from(packed: PackedVertex<N, X, Y>) -> Vertex {
         let mut ar = [0; 4];
-        for i in 0..packed.data.len() {
-            ar[i] = packed.data[i];
-        }
+        ar[..packed.data.len()].copy_from_slice(&packed.data[..]);
         let data = u32::from_le_bytes(ar);
         let x_mask = (1 << X) - 1;
         let y_mask = (1 << Y) - 1;

--- a/psx/src/hw/cdrom/controller.rs
+++ b/psx/src/hw/cdrom/controller.rs
@@ -9,6 +9,6 @@ impl Controller {
 
 impl Parameter {
     pub fn set_param(&mut self, param: u8) -> &mut Self {
-        self.assign(param as u8)
+        self.assign(param)
     }
 }

--- a/psx/src/hw/gpu/gp0.rs
+++ b/psx/src/hw/gpu/gp0.rs
@@ -35,7 +35,7 @@ impl GP0 {
     /// without dropping some commands. This will not corrupt memory, but may
     /// cause unintended on-screen effects.
     // TODO: Make this unsafe
-    pub fn send_command<C: GP0Command + ?Sized>(&mut self, cmd: &C) -> &mut Self {
+    pub fn send_command<C: GP0Command>(&mut self, cmd: &C) -> &mut Self {
         for &word in cmd.data() {
             self.assign(word).store();
         }

--- a/psx/src/hw/gpu/status.rs
+++ b/psx/src/hw/gpu/status.rs
@@ -118,3 +118,9 @@ impl Debug for Status {
             .finish()
     }
 }
+
+impl Default for Status {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/psx/src/lib.rs
+++ b/psx/src/lib.rs
@@ -31,13 +31,9 @@
 #![no_std]
 #![deny(missing_docs)]
 // For compile-time Wavefront OBJ parser
-#![feature(const_mut_refs, maybe_uninit_array_assume_init)]
+#![feature(maybe_uninit_array_assume_init)]
 // Used to make `AsCStr` efficient
-#![feature(
-    maybe_uninit_uninit_array,
-    maybe_uninit_slice,
-    maybe_uninit_write_slice
-)]
+#![feature(maybe_uninit_slice, maybe_uninit_write_slice)]
 // Used to implement `ImplsAsCStr` trait
 #![feature(min_specialization)]
 // For global_asm! on MIPS
@@ -50,6 +46,8 @@
 #![feature(variant_count)]
 // Used for crate tests
 #![feature(custom_test_frameworks)]
+// Used for ergonomic uninit array initialization
+#![feature(maybe_uninit_fill)]
 #![test_runner(crate::test::runner)]
 #![reexport_test_harness_main = "main"]
 #![cfg_attr(test, no_main)]
@@ -109,6 +107,7 @@ pub mod constants {
     /// The start of the data cache.
     pub const DATA_CACHE: usize = 0x1F80_0000;
     /// The size of the data cache.
+    #[expect(clippy::identity_op, reason = "KB used as a unit for clarity")]
     pub const DATA_CACHE_LEN: usize = 1 * KB;
 
     /// The entrypoint of the post-boot function.
@@ -137,7 +136,9 @@ pub struct CriticalSection(());
 impl CriticalSection {
     /// Creates a new critical section token
     ///
-    /// # SAFETY: Since owning a CriticalSection means we are in a critical
+    /// # SAFETY
+    ///
+    /// Since owning a CriticalSection means we are in a critical
     /// section, this is only safe to create if we are actually in a critical
     /// section.
     pub unsafe fn new() -> Self {

--- a/psx/src/math.rs
+++ b/psx/src/math.rs
@@ -182,7 +182,7 @@ pub fn sin(x: Rad) -> f16 {
 
 /// Computes cosine using a lookup table.
 pub fn cos(x: Rad) -> f16 {
-    let quarter_cycle = FRAC_PI_2.0 as u16;
+    let quarter_cycle = FRAC_PI_2.0;
     let cycle = x.0 / quarter_cycle;
     let offset = x.0 % quarter_cycle;
     let idx = COSINE_TABLE_SIZE * (offset as usize) / quarter_cycle as usize;

--- a/psx/src/std.rs
+++ b/psx/src/std.rs
@@ -31,16 +31,15 @@ impl<T: AsRef<[u8]>> AsCStr for T {
                     );
                 }
                 // Create an uninitialized array of up to 128 bytes on the stack
-                let mut uninitialized = MaybeUninit::uninit_array::<MAX_LEN>();
+                let mut uninitialized = [const { MaybeUninit::uninit() }; MAX_LEN];
                 // Initialize the CStr with the input string
                 let initialized_part = &mut uninitialized[0..slice.len() + 1];
-                MaybeUninit::copy_from_slice(&mut initialized_part[0..slice.len()], slice);
+                initialized_part[0..slice.len()].write_copy_of_slice(slice);
                 // Add a null-terminator to the CStr
                 initialized_part[slice.len()].write(0);
                 // SAFETY: The initialized portion of the CStr on the stack was explicitly
                 // initialized and null-terminated
-                let terminated_slice =
-                    unsafe { MaybeUninit::slice_assume_init_ref(initialized_part) };
+                let terminated_slice = unsafe { initialized_part.assume_init_ref() };
                 // SAFETY: We null-terminated the initialized part of slice
                 let cstr = unsafe { CStr::from_bytes_with_nul_unchecked(terminated_slice) };
                 f(cstr)

--- a/psx/src/sys/fs.rs
+++ b/psx/src/sys/fs.rs
@@ -41,7 +41,12 @@ pub struct DirEntry {
 }
 
 impl DirEntry {
-    pub unsafe fn from_bytes(ptr: *const [u8; 40]) -> DirEntry {
+    /// Create a [`DirEntry`] from the provided byte array.
+    ///
+    /// # Safety
+    ///
+    /// The provided bytes must represent a valid [`DirEntry`].
+    pub unsafe fn from_bytes(ptr: *const [u8; size_of::<Self>()]) -> Self {
         *ptr.cast()
     }
 }
@@ -57,6 +62,10 @@ impl Debug for DirEntry {
 
 // TODO: Explain why bugs make this unsafe. It would be possible to make an
 // iterator safe by making it eager but that may not be practical
+#[expect(
+    clippy::missing_safety_doc,
+    reason = "TODO: Explain why bugs make this unsafe. It would be possible to make an iterator safe by making it eager but that may not be practical"
+)]
 pub unsafe fn first_file<P: AsRef<[u8]>>(path: P) -> Option<DirEntry> {
     path.as_cstr(|path| {
         let dir_entry = kernel::psx_first_file(path.as_ptr());
@@ -68,6 +77,7 @@ pub unsafe fn first_file<P: AsRef<[u8]>>(path: P) -> Option<DirEntry> {
     })
 }
 
+#[expect(clippy::missing_safety_doc, reason = "TODO: add documentation")]
 pub unsafe fn next_file() -> Option<DirEntry> {
     let dir_entry = kernel::psx_next_file();
     if dir_entry.is_null() {

--- a/psx/src/sys/gamepad.rs
+++ b/psx/src/sys/gamepad.rs
@@ -110,6 +110,10 @@ impl<'a> Gamepad<'a> {
     /// Note that the buffer is embedded in the executable. To use a temporary
     /// buffer (e.g. to minimize executable size) use `Gamepad::new_with_buffer`
     /// directly.
+    #[expect(
+        clippy::new_without_default,
+        reason = "new implementation not currently safe, Default would encourage it's use"
+    )]
     pub fn new() -> Self {
         static mut BUFFER1: MaybeUninit<[u32; BUFFER_SIZE]> = MaybeUninit::uninit();
         static mut BUFFER2: MaybeUninit<[u32; BUFFER_SIZE]> = MaybeUninit::uninit();
@@ -117,7 +121,7 @@ impl<'a> Gamepad<'a> {
         // destructors the BIOS will still manage these buffers. However, they have a
         // static lifetime and cannot be access from anywhere else so it's effectively
         // just leaking the buffers.
-        unsafe { Self::new_with_buffer(&mut BUFFER1, &mut BUFFER2) }
+        unsafe { Self::new_with_buffer_ptr(&raw mut BUFFER1, &raw mut BUFFER2) }
     }
 
     /// Creates a new gamepad from a reference to a buffer.
@@ -137,8 +141,25 @@ impl<'a> Gamepad<'a> {
         buf1: &'a mut MaybeUninit<[u32; BUFFER_SIZE]>,
         buf2: &'a mut MaybeUninit<[u32; BUFFER_SIZE]>,
     ) -> Self {
-        let buf1 = buf1.as_mut_ptr().cast::<u16>();
-        let buf2 = buf2.as_mut_ptr().cast::<u16>();
+        // SAFETY: Provided buffers have 'a lifetime.
+        Self::new_with_buffer_ptr(buf1, buf2)
+    }
+
+    /// Creates a new gamepad from a pointer to a buffer.
+    ///
+    /// # SAFETY
+    ///
+    /// The provided buffers must be valid for the entire lifetime 'a.
+    /// Since the buffer passed to the BIOS may be dynamic, the BIOS must stop
+    /// modifying them when the Gamepad is dropped. This is done by calling
+    /// `stop_pad` in `Gamepad`'s destructor. Dropping `Gamepad` without running
+    /// its destructor or manuall calling `stop_pad` on the managed buffers will
+    /// lead to *undefined behavior*.
+    unsafe fn new_with_buffer_ptr(
+        buf1: *mut MaybeUninit<[u32; BUFFER_SIZE]>, buf2: *mut MaybeUninit<[u32; BUFFER_SIZE]>,
+    ) -> Self {
+        let buf1 = buf1.cast::<u16>();
+        let buf2 = buf2.cast::<u16>();
         kernel::psx_init_pad(buf1 as *mut u8, 0x22, buf2 as *mut u8, 0x22);
         // Set the status byte to not ok since init_pad zerofills the buffer
         buf1.cast::<u8>().write_volatile(0xFF);
@@ -213,7 +234,7 @@ impl Iterator for Buttons {
             return None
         }
         let this_bit = self.iter_idx;
-        let bit_value = (self.value >> (this_bit as u16)) & 1;
+        let bit_value = (self.value >> this_bit) & 1;
         self.iter_idx += 1;
         if bit_value == 0 {
             Button::from_bit(this_bit)

--- a/psx/src/sys/rng.rs
+++ b/psx/src/sys/rng.rs
@@ -35,8 +35,8 @@ impl Rng {
         let mut res = T::from(0);
         let ptr = &mut res as *mut T as *mut u8;
         let slice = unsafe { slice::from_raw_parts_mut(ptr, size_of::<T>()) };
-        for n in 0..slice.len() {
-            slice[n] = self.step() as u8;
+        for item in slice {
+            *item = self.step() as u8;
         }
         res
     }

--- a/psx/src/sys/tty.rs
+++ b/psx/src/sys/tty.rs
@@ -23,7 +23,7 @@ impl<const N: usize> ImplsAsCStr for [u8; N] {
 }
 impl ImplsAsCStr for &[u8] {
     fn impls_as_cstr(&self) -> Option<&[u8]> {
-        Some(self.as_ref())
+        Some(self)
     }
 }
 impl ImplsAsCStr for &str {
@@ -122,7 +122,7 @@ impl fmt::Write for TTY {
         msg.as_cstr(|cstr|
             // SAFETY: The format string and string argument are both null-terminated.
             unsafe {
-                kernel::psx_printf(b"%s\0".as_ptr() as *const i8, cstr.as_ptr());
+                kernel::psx_printf(c"%s".as_ptr(), cstr.as_ptr());
             });
         Ok(())
     }


### PR DESCRIPTION
# Objective

Experimenting with #39, I'd like to use a newer version of the nightly compiler so that if we're able to make progress on #6, it'll be on a recent compiler.

## Solution

- Updated to `nightly-2025-05-23`
- Updated `psx/.cargo/config.toml` to include configuration arguments required for a typical `cargo build` to function correctly.
- Added an `unexpected_cfgs` entry to suppress the `nonexistent_feature` warning.
- Added a `rust-toolchain.toml` with the validated toolchain version.
- Acted on clippy lints from the newer toolchain.

---

## Notes

Most changes are relatively minor, but double-check some of the adjusted algorithms. For example, one of the clippy lints was to avoid iterating an integer just to index an array.