### PR TITLE
Add `critical-section` Feature

### DIFF
--- a/psx/Cargo.toml
+++ b/psx/Cargo.toml
@@ -40,7 +40,6 @@ loadable_exe = []
 custom_oom = []
 heap = ["dep:linked_list_allocator"]
 nightlier = []
-# Provides a `critical-section` implementation using BIOS sys-calls.
 critical-section = ["dep:critical-section"]
 
 [lints.rust]

--- a/psx/Cargo.toml
+++ b/psx/Cargo.toml
@@ -18,6 +18,7 @@ cargo-args = ["--features", "psx/heap"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+critical-section = { version = "1", features = ["restore-state-bool"], optional = true }
 
 [dependencies.linked_list_allocator]
 version = "0.10.3"
@@ -39,6 +40,8 @@ loadable_exe = []
 custom_oom = []
 heap = ["dep:linked_list_allocator"]
 nightlier = []
+# Provides a `critical-section` implementation using BIOS sys-calls.
+critical-section = ["dep:critical-section"]
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = [

--- a/psx/src/critical_section_impl.rs
+++ b/psx/src/critical_section_impl.rs
@@ -1,0 +1,22 @@
+use critical_section::RawRestoreState;
+
+use crate::sys::kernel;
+
+/// Implements [`critical-section`](critical_section) using BIOS sys-calls.
+struct BIOSCriticalSection;
+
+critical_section::set_impl!(BIOSCriticalSection);
+
+unsafe impl critical_section::Impl for BIOSCriticalSection {
+    unsafe fn acquire() -> RawRestoreState {
+        unsafe { kernel::psx_enter_critical_section() }
+    }
+
+    unsafe fn release(token: RawRestoreState) {
+        if token {
+            unsafe {
+                kernel::psx_exit_critical_section();
+            }
+        };
+    }
+}

--- a/psx/src/lib.rs
+++ b/psx/src/lib.rs
@@ -54,6 +54,8 @@
 #[macro_use]
 mod test;
 
+#[cfg(feature = "critical-section")]
+mod critical_section_impl;
 pub mod dma;
 pub mod format;
 mod framebuffer;

--- a/psx/src/lib.rs
+++ b/psx/src/lib.rs
@@ -27,6 +27,8 @@
 //!   this requires [building and patching LLVM](https://github.com/ayrtonm/psx-sdk-rs/tree/master/patches#rustc-build-instructions) as part of the rustc build.
 //!   Currently this enables [`Atomic*`][core::sync::atomic] up to 16-bits and
 //!   [`fences`][core::sync::atomic::compiler_fence].
+//! * `critical-section` - Provides a [`critical-section`](https://crates.io/crates/critical-section)
+//!   implementation using BIOS sys-calls.
 
 #![no_std]
 #![deny(missing_docs)]


### PR DESCRIPTION
# Objective

`critical-section` is a typical API in the embedded ecosystem for things like `portable-atomic`, `spin`, and many other useful crates. `psx` provides its own variant of this API, so it'd be nice to integrate with the more commonly use API!

## Solution

- Added `critical-section` feature based on the BIOS sys-calls.

---

## Notes

I noticed there are actually two different ways to gain a critical section in the SDK; one using sys-calls, and the other using `cop0::Status::new().critical_section(...)`. I've chosen the sys-call version for the implementation, but let me know if the `cop0` version would be more appropriate! I'm still learning how the PSX works at a hardware level so I'm somewhat ignorant here.

Also note this PR is actually very small, but is branched from #41, so it includes diffs from there too. All the relevant changes are in `critical_section_impl.rs`.