### PR TITLE
Fixed MaybeUninit::uninit_array() errors due to removal

### DIFF
--- a/psx/src/format/obj.rs
+++ b/psx/src/format/obj.rs
@@ -181,9 +181,9 @@ impl<
     > Obj<'a, VERTICES, NORMALS, QUADS, TRIS, FACES>
 {
     /// Creates an array by calling `f` for each face.
-    pub fn for_each_face<T, F>(&self, mut f: F) -> [T; FACES]
+    pub fn for_each_face<T: Copy, F>(&self, mut f: F) -> [T; FACES]
     where F: FnMut() -> T {
-        let mut res = MaybeUninit::uninit_array();
+        let mut res = [MaybeUninit::uninit(); FACES];
         for n in 0..QUADS + TRIS {
             res[n].write(f());
         }
@@ -192,11 +192,11 @@ impl<
 
     /// Creates an array by applying `f_quad` to each quad and `f_tri` to each
     /// tri.
-    pub fn map_faces<T, F, G>(&self, mut f_quad: F, mut f_tri: G) -> [T; FACES]
+    pub fn map_faces<T: Copy, F, G>(&self, mut f_quad: F, mut f_tri: G) -> [T; FACES]
     where
         F: FnMut([u16; 4]) -> T,
         G: FnMut([u16; 3]) -> T, {
-        let mut res = MaybeUninit::uninit_array();
+        let mut res = [MaybeUninit::uninit(); FACES];
         for n in 0..QUADS + TRIS {
             if n < QUADS {
                 res[n].write(f_quad(self.quads[n]));

--- a/psx/src/lib.rs
+++ b/psx/src/lib.rs
@@ -31,13 +31,9 @@
 #![no_std]
 #![deny(missing_docs)]
 // For compile-time Wavefront OBJ parser
-#![feature(const_mut_refs, maybe_uninit_array_assume_init)]
+#![feature(maybe_uninit_array_assume_init)]
 // Used to make `AsCStr` efficient
-#![feature(
-    maybe_uninit_uninit_array,
-    maybe_uninit_slice,
-    maybe_uninit_write_slice
-)]
+#![feature(maybe_uninit_fill, maybe_uninit_slice, maybe_uninit_write_slice)]
 // Used to implement `ImplsAsCStr` trait
 #![feature(min_specialization)]
 // For global_asm! on MIPS

--- a/psx/src/std.rs
+++ b/psx/src/std.rs
@@ -31,16 +31,15 @@ impl<T: AsRef<[u8]>> AsCStr for T {
                     );
                 }
                 // Create an uninitialized array of up to 128 bytes on the stack
-                let mut uninitialized = MaybeUninit::uninit_array::<MAX_LEN>();
+                let mut uninitialized = [MaybeUninit::<u8>::uninit(); MAX_LEN];
                 // Initialize the CStr with the input string
-                let initialized_part = &mut uninitialized[0..slice.len() + 1];
-                MaybeUninit::copy_from_slice(&mut initialized_part[0..slice.len()], slice);
+                let initialized = &mut uninitialized[0..slice.len() + 1];
+                initialized.write_iter(slice.iter().map(|v| *v));
                 // Add a null-terminator to the CStr
-                initialized_part[slice.len()].write(0);
+                initialized[slice.len()].write(0);
                 // SAFETY: The initialized portion of the CStr on the stack was explicitly
                 // initialized and null-terminated
-                let terminated_slice =
-                    unsafe { MaybeUninit::slice_assume_init_ref(initialized_part) };
+                let terminated_slice = unsafe { initialized.assume_init_ref() };
                 // SAFETY: We null-terminated the initialized part of slice
                 let cstr = unsafe { CStr::from_bytes_with_nul_unchecked(terminated_slice) };
                 f(cstr)


### PR DESCRIPTION
I see MaybeUninit::uninit_array() has been removed from Rust, not allowing psx to compile. I have reworked the use of MaybeUninit to allow psx to compile.