### PR TITLE
psx/hw/cop: Support cfc2 and ctc2 op codes to access GTE Control Registers

### DIFF
--- a/psx/src/hw/cop.rs
+++ b/psx/src/hw/cop.rs
@@ -37,6 +37,7 @@ macro_rules! define_cop {
                         //concat!($cop_ty, "fc", $cop, " {}, $", $reg),
                         ".set noat",
                         concat!(".long 1<<30 | ", $cop, "<<26 | (0x", $cop_ty, "/6)<<21 | 1 << 16 | (", $reg, " - 0x", $cop_ty, "/12*32) << 11"),
+                        "nop",
                         "addiu {}, $at, 0",
                         ".set at",
                         out(reg) self.value,

--- a/psx/src/hw/cop.rs
+++ b/psx/src/hw/cop.rs
@@ -20,21 +20,21 @@ impl<T: Primitive, const COP: u32, const REG: u32> AsMut<T> for CopRegister<T, C
 }
 
 macro_rules! cop_move {
-    ("m", from, $cop:expr, $reg:expr) => {
+    (m, from, $cop:expr, $reg:expr) => {
         concat!(
             "mfc", $cop, " {}, $", $reg, "\n",
             "nop\n",
             "nop", // 2 delay slots required to ensure value is in out(reg)
         )
     };
-    ("m", to, $cop:expr, $reg:expr) => {
+    (m, to, $cop:expr, $reg:expr) => {
         concat!("mtc", $cop, " {}, $", $reg, "\n",
             "nop\n",
             "nop"
         )
     };
-    ("c", from, $cop:expr, $reg:expr) => {
-        //concat!("cfc", $cop, " {}, $", $reg) # Not currently supported by LLVM
+    (c, from, $cop:expr, $reg:expr) => {
+        // cfc2 not currently supported by LLVM
         concat!(
             //       cop      n             CF      rt=$at   rd=$reg - 32
             ".long 1<<30 | ", $cop, "<<26 | 2<<21 | 1<<16 | (", $reg, "-32)<<11 # cfc", $cop, "\n",
@@ -43,8 +43,8 @@ macro_rules! cop_move {
             "addiu {}, $at, 0"
         )
     };
-    ("c", to, $cop:expr, $reg:expr) => {
-        //concat!("ctc", $cop, " {}, $", $reg) # Not currently supported by LLVM
+    (c, to, $cop:expr, $reg:expr) => {
+        // ctc2 not currently supported by LLVM
         concat!(
             "addiu $at, {}, 0\n",
             //       cop      n             CT      rt=$at   rd=$reg - 32
@@ -57,9 +57,9 @@ macro_rules! cop_move {
 
 macro_rules! define_cop {
     ($(#[$($meta:meta)*])* $name:ident <$ty:ty>; COP: $cop:expr; R: $reg:expr $(,)?) => {
-        define_cop!($(#[$($meta)*])* $name<$ty>; COP: $cop; R: $reg; "m");
+        define_cop!($(#[$($meta)*])* $name<$ty>; COP: $cop; R: $reg; m);
     };
-    ($(#[$($meta:meta)*])* $name:ident <$ty:ty>; COP: $cop:expr; R: $reg:expr; $cop_ty:tt $(,)?) => {
+    ($(#[$($meta:meta)*])* $name:ident <$ty:ty>; COP: $cop:expr; R: $reg:expr; $cop_ty:ident $(,)?) => {
         $(#[$($meta)*])*
         pub type $name = crate::hw::cop::CopRegister<$ty, $cop, $reg>;
 
@@ -94,7 +94,7 @@ macro_rules! define_cop {
             }
         }
     };
-    ($(#[$($meta:meta)*])* $name:ident <$ty:ty>; COP: $cop:expr; R: $reg:expr $(;$cop_ty:tt)?, $($others:tt)*) => {
+    ($(#[$($meta:meta)*])* $name:ident <$ty:ty>; COP: $cop:expr; R: $reg:expr $(;$cop_ty:ident)?, $($others:tt)*) => {
         define_cop!($(#[$($meta)*])* $name<$ty>; COP: $cop; R: $reg $(;$cop_ty)*);
         define_cop!($($others)*);
     };

--- a/psx/src/hw/cop.rs
+++ b/psx/src/hw/cop.rs
@@ -35,9 +35,19 @@ macro_rules! cop_move {
     };
     (c, from, $cop:expr, $reg:expr) => {
         // cfc2 not currently supported by LLVM
+        // MIPS CFCn (Move Control From Coprocessor) instruction layout:
+        // 31    26 25   21 20   16 15   11 10           0
+        // +-------+-------+-------+-------+--------------+
+        // | COPn  |  CF   |  rt   |  rd   |  Padding     |
+        // | 0100nn| 00010 | 00001 | reg-32| 000 0000 0000|
+        // +-------+-------+-------+-------+--------------+
+        //     6       5       5       5        11
+        // - COPn: Opcode prefix (0x10 | $cop) -> 1 << 30 | ($cop << 26)
+        // - CF:   Coprocessor sub-operation 'Move Control From' -> 2 << 21
+        // - rt:   General purpose register (destination). Hardcoded to 1 ($at) -> 1 << 16
+        // - rd:   Coprocessor control register (source) -> ($reg - 32) << 11
         concat!(
-            //       cop      n             CF      rt=$at   rd=$reg - 32
-            ".long 1<<30 | ", $cop, "<<26 | 2<<21 | 1<<16 | (", $reg, "-32)<<11 # cfc", $cop, "\n",
+            ".long (1 << 30) | (", $cop, " << 26) | (2 << 21) | (1 << 16) | ((", $reg, " - 32) << 11) # cfc", $cop, "\n",
             "nop\n",
             "nop\n",
             "addiu {}, $at, 0"
@@ -45,10 +55,20 @@ macro_rules! cop_move {
     };
     (c, to, $cop:expr, $reg:expr) => {
         // ctc2 not currently supported by LLVM
+        // MIPS CTCn (Move Control to Coprocessor) instruction layout:
+        // 31    26 25   21 20   16 15   11 10           0
+        // +-------+-------+-------+-------+--------------+
+        // | COPn  |  CT   |  rt   |  rd   |  Padding     |
+        // | 0100nn| 00110 | 00001 | reg-32| 000 0000 0000|
+        // +-------+-------+-------+-------+--------------+
+        //     6       5       5       5        11
+        // - COPn: Opcode prefix (0x10 | $cop) -> 1 << 30 | ($cop << 26)
+        // - CT:   Coprocessor sub-operation 'Move Control To' -> 6 << 21
+        // - rt:   General purpose register (source). Hardcoded to 1 ($at) -> 1 << 16
+        // - rd:   Coprocessor control register (destination) -> ($reg - 32) << 11
         concat!(
             "addiu $at, {}, 0\n",
-            //       cop      n             CT      rt=$at   rd=$reg - 32
-            ".long 1<<30 | ", $cop, "<<26 | 6<<21 | 1<<16 | (", $reg, "-32)<<11 # ctc", $cop, "\n",
+            ".long (1 << 30) | (", $cop, " << 26) | (6 << 21) | (1 << 16) | ((", $reg, " - 32) << 11) # ctc", $cop, "\n",
             "nop\n",
             "nop",
         )

--- a/psx/src/hw/cop.rs
+++ b/psx/src/hw/cop.rs
@@ -23,17 +23,22 @@ macro_rules! cop_move {
     ("m", from, $cop:expr, $reg:expr) => {
         concat!(
             "mfc", $cop, " {}, $", $reg, "\n",
-            "nop"  // required to ensure value is in out(reg)
+            "nop\n",
+            "nop", // 2 delay slots required to ensure value is in out(reg)
         )
     };
     ("m", to, $cop:expr, $reg:expr) => {
-        concat!("mtc", $cop, " {}, $", $reg)
+        concat!("mtc", $cop, " {}, $", $reg, "\n",
+            "nop\n",
+            "nop"
+        )
     };
     ("c", from, $cop:expr, $reg:expr) => {
         //concat!("cfc", $cop, " {}, $", $reg) # Not currently supported by LLVM
         concat!(
             //       cop      n             CF      rt=$at   rd=$reg - 32
             ".long 1<<30 | ", $cop, "<<26 | 2<<21 | 1<<16 | (", $reg, "-32)<<11 # cfc", $cop, "\n",
+            "nop\n",
             "nop\n",
             "addiu {}, $at, 0"
         )
@@ -43,7 +48,9 @@ macro_rules! cop_move {
         concat!(
             "addiu $at, {}, 0\n",
             //       cop      n             CT      rt=$at   rd=$reg - 32
-            ".long 1<<30 | ", $cop, "<<26 | 6<<21 | 1<<16 | (", $reg, "-32)<<11 # ctc", $cop
+            ".long 1<<30 | ", $cop, "<<26 | 6<<21 | 1<<16 | (", $reg, "-32)<<11 # ctc", $cop, "\n",
+            "nop\n",
+            "nop",
         )
     };
 }

--- a/psx/src/hw/cop.rs
+++ b/psx/src/hw/cop.rs
@@ -35,7 +35,10 @@ macro_rules! define_cop {
                 unsafe {
                     core::arch::asm! {
                         //concat!($cop_ty, "fc", $cop, " {}, $", $reg),
-                        concat!(".long 1<<30 | ", $cop, "<<26 | (0x", $cop_ty, "/6)<<21 | 1 << 16 | (", $reg, " - 0x", $cop_ty, "/12*32) << 11 # {}"),
+                        ".set noat",
+                        concat!(".long 1<<30 | ", $cop, "<<26 | (0x", $cop_ty, "/6)<<21 | 1 << 16 | (", $reg, " - 0x", $cop_ty, "/12*32) << 11"),
+                        "addiu {}, $at, 0",
+                        ".set at",
                         out(reg) self.value,
                         options(nomem, nostack)
                     }
@@ -47,7 +50,10 @@ macro_rules! define_cop {
                 unsafe {
                     core::arch::asm! {
                         //concat!($cop_ty, "tc", $cop, " {}, $", $reg),
-                        concat!(".long 1<<30 | ", $cop, "<<26 | 1<<23 | (0x", $cop_ty, "/6)<<21 | 1 << 16 | (", $reg, " - 0x", $cop_ty, "/12*32) << 11 # {}"),
+                        ".set noat",
+                        "addiu $at, {}, 0",
+                        concat!(".long 1<<30 | ", $cop, "<<26 | 1<<23 | (0x", $cop_ty, "/6)<<21 | 1 << 16 | (", $reg, " - 0x", $cop_ty, "/12*32) << 11"),
+                        ".set at",
                         in(reg) self.value,
                         options(nomem, nostack)
                     }

--- a/psx/src/hw/cop.rs
+++ b/psx/src/hw/cop.rs
@@ -21,7 +21,7 @@ impl<T: Primitive, const COP: u32, const REG: u32> AsMut<T> for CopRegister<T, C
 
 macro_rules! define_cop {
     ($(#[$($meta:meta)*])* $name:ident <$ty:ty>; COP: $cop:expr; R: $reg:expr $(,)?) => {
-        define_cop!($(#[$($meta)*])* $name<$ty>; COP: $cop; R: $reg; "m");
+        define_cop!($(#[$($meta)*])* $name<$ty>; COP: $cop; R: $reg; "0");
     };
     ($(#[$($meta:meta)*])* $name:ident <$ty:ty>; COP: $cop:expr; R: $reg:expr; $cop_ty:literal $(,)?) => {
         $(#[$($meta)*])*
@@ -34,9 +34,8 @@ macro_rules! define_cop {
             fn load(&mut self) -> &mut Self {
                 unsafe {
                     core::arch::asm! {
-                        ".set noat",
-                        concat!($cop_ty, "fc", $cop, " {}, $", $reg),
-                        ".set at",
+                        //concat!($cop_ty, "fc", $cop, " {}, $", $reg),
+                        concat!(".long 1<<30 | ", $cop, "<<26 | (0x", $cop_ty, "/6)<<21 | 1 << 16 | (", $reg, " - 0x", $cop_ty, "/12*32) << 11 # {}"),
                         out(reg) self.value,
                         options(nomem, nostack)
                     }
@@ -47,9 +46,8 @@ macro_rules! define_cop {
             fn store(&mut self) -> &mut Self {
                 unsafe {
                     core::arch::asm! {
-                        ".set noat",
-                        concat!($cop_ty, "tc", $cop, " {}, $", $reg),
-                        ".set at",
+                        //concat!($cop_ty, "tc", $cop, " {}, $", $reg),
+                        concat!(".long 1<<30 | ", $cop, "<<26 | 1<<23 | (0x", $cop_ty, "/6)<<21 | 1 << 16 | (", $reg, " - 0x", $cop_ty, "/12*32) << 11 # {}"),
                         in(reg) self.value,
                         options(nomem, nostack)
                     }

--- a/psx/src/hw/cop.rs
+++ b/psx/src/hw/cop.rs
@@ -19,11 +19,40 @@ impl<T: Primitive, const COP: u32, const REG: u32> AsMut<T> for CopRegister<T, C
     }
 }
 
+macro_rules! cop_move {
+    ("m", from, $cop:expr, $reg:expr) => {
+        concat!(
+            "mfc", $cop, " {}, $", $reg, "\n",
+            "nop"  // required to ensure value is in out(reg)
+        )
+    };
+    ("m", to, $cop:expr, $reg:expr) => {
+        concat!("mtc", $cop, " {}, $", $reg)
+    };
+    ("c", from, $cop:expr, $reg:expr) => {
+        //concat!("cfc", $cop, " {}, $", $reg) # Not currently supported by LLVM
+        concat!(
+            //       cop      n             CF      rt=$at   rd=$reg - 32
+            ".long 1<<30 | ", $cop, "<<26 | 2<<21 | 1<<16 | (", $reg, "-32)<<11 # cfc", $cop, "\n",
+            "nop\n",
+            "addiu {}, $at, 0"
+        )
+    };
+    ("c", to, $cop:expr, $reg:expr) => {
+        //concat!("ctc", $cop, " {}, $", $reg) # Not currently supported by LLVM
+        concat!(
+            "addiu $at, {}, 0\n",
+            //       cop      n             CT      rt=$at   rd=$reg - 32
+            ".long 1<<30 | ", $cop, "<<26 | 6<<21 | 1<<16 | (", $reg, "-32)<<11 # ctc", $cop
+        )
+    };
+}
+
 macro_rules! define_cop {
     ($(#[$($meta:meta)*])* $name:ident <$ty:ty>; COP: $cop:expr; R: $reg:expr $(,)?) => {
-        define_cop!($(#[$($meta)*])* $name<$ty>; COP: $cop; R: $reg; "0");
+        define_cop!($(#[$($meta)*])* $name<$ty>; COP: $cop; R: $reg; "m");
     };
-    ($(#[$($meta:meta)*])* $name:ident <$ty:ty>; COP: $cop:expr; R: $reg:expr; $cop_ty:literal $(,)?) => {
+    ($(#[$($meta:meta)*])* $name:ident <$ty:ty>; COP: $cop:expr; R: $reg:expr; $cop_ty:tt $(,)?) => {
         $(#[$($meta)*])*
         pub type $name = crate::hw::cop::CopRegister<$ty, $cop, $reg>;
 
@@ -34,11 +63,8 @@ macro_rules! define_cop {
             fn load(&mut self) -> &mut Self {
                 unsafe {
                     core::arch::asm! {
-                        //concat!($cop_ty, "fc", $cop, " {}, $", $reg),
                         ".set noat",
-                        concat!(".long 1<<30 | ", $cop, "<<26 | (0x", $cop_ty, "/6)<<21 | 1 << 16 | (", $reg, " - 0x", $cop_ty, "/12*32) << 11"),
-                        "nop",
-                        "addiu {}, $at, 0",
+                        cop_move!($cop_ty, from, $cop, $reg),
                         ".set at",
                         out(reg) self.value,
                         options(nomem, nostack)
@@ -50,10 +76,8 @@ macro_rules! define_cop {
             fn store(&mut self) -> &mut Self {
                 unsafe {
                     core::arch::asm! {
-                        //concat!($cop_ty, "tc", $cop, " {}, $", $reg),
                         ".set noat",
-                        "addiu $at, {}, 0",
-                        concat!(".long 1<<30 | ", $cop, "<<26 | 1<<23 | (0x", $cop_ty, "/6)<<21 | 1 << 16 | (", $reg, " - 0x", $cop_ty, "/12*32) << 11"),
+                        cop_move!($cop_ty, to, $cop, $reg),
                         ".set at",
                         in(reg) self.value,
                         options(nomem, nostack)
@@ -63,7 +87,7 @@ macro_rules! define_cop {
             }
         }
     };
-    ($(#[$($meta:meta)*])* $name:ident <$ty:ty>; COP: $cop:expr; R: $reg:expr $(;$cop_ty:literal)?, $($others:tt)*) => {
+    ($(#[$($meta:meta)*])* $name:ident <$ty:ty>; COP: $cop:expr; R: $reg:expr $(;$cop_ty:tt)?, $($others:tt)*) => {
         define_cop!($(#[$($meta)*])* $name<$ty>; COP: $cop; R: $reg $(;$cop_ty)*);
         define_cop!($($others)*);
     };

--- a/psx/src/hw/gte.rs
+++ b/psx/src/hw/gte.rs
@@ -45,7 +45,6 @@ define_cop! {
     /// Leading zeros count result
     LZCR<u32>; COP: 2; R: 31,
 
-    // TODO: LLVM doesn't support these coprocessor instructions yet (#7).
     /// Rotation matrix entries RT11 and RT12
     RT11_12<u32>; COP: 2; R: 32; "c",
 

--- a/psx/src/hw/gte.rs
+++ b/psx/src/hw/gte.rs
@@ -21,6 +21,15 @@ define_cop! {
     /// Ordering table average Z value
     OTZ<u16>;  COP: 2; R: 7,
 
+    /// Intermediate value 0
+    IR0<i32>; COP: 2; R: 8,
+    /// Intermediate value 1
+    IR1<i32>; COP: 2; R: 9,
+    /// Intermediate value 2
+    IR2<i32>; COP: 2; R: 10,
+    /// Intermediate value 3
+    IR3<i32>; COP: 2; R: 11,
+
     /// Scalar math accumulator
     MAC0<i32>; COP: 2; R: 24,
 

--- a/psx/src/hw/gte.rs
+++ b/psx/src/hw/gte.rs
@@ -80,77 +80,77 @@ define_cop! {
     LZCR<u32>; COP: 2; R: 31,
 
     /// Rotation matrix entries RT11 and RT12
-    RT11_12<u32>; COP: 2; R: 32; "c",
+    RT11_12<u32>; COP: 2; R: 32; c,
 
     /// Rotation matrix entries RT13 and RT21
-    RT13_21<u32>; COP: 2; R: 33; "c",
+    RT13_21<u32>; COP: 2; R: 33; c,
     /// Rotation matrix entries RT22 and RT23
-    RT22_23<u32>; COP: 2; R: 34; "c",
+    RT22_23<u32>; COP: 2; R: 34; c,
     /// Rotation matrix entries RT31 and RT32
-    RT31_32<u32>; COP: 2; R: 35; "c",
+    RT31_32<u32>; COP: 2; R: 35; c,
     /// Rotation matrix entry RT33
-    RT33<i16>;    COP: 2; R: 36; "c",
+    RT33<i16>;    COP: 2; R: 36; c,
 
     /// Translation vector X
-    TRX<i32>; COP: 2; R: 37; "c",
+    TRX<i32>; COP: 2; R: 37; c,
     /// Translation vector Y
-    TRY<i32>; COP: 2; R: 38; "c",
+    TRY<i32>; COP: 2; R: 38; c,
     /// Translation vector Z
-    TRZ<i32>; COP: 2; R: 39; "c",
+    TRZ<i32>; COP: 2; R: 39; c,
 
     /// Light matrix entries L11 and L12
-    L11_12<u32>; COP: 2; R: 40; "c",
+    L11_12<u32>; COP: 2; R: 40; c,
     /// Light matrix entries L13 and L21
-    L13_21<u32>; COP: 2; R: 41; "c",
+    L13_21<u32>; COP: 2; R: 41; c,
     /// Light matrix entries L22 and L23
-    L22_23<u32>; COP: 2; R: 42; "c",
+    L22_23<u32>; COP: 2; R: 42; c,
     /// Light matrix entries L31 and L32
-    L31_32<u32>; COP: 2; R: 43; "c",
+    L31_32<u32>; COP: 2; R: 43; c,
     /// Light matrix entry L33
-    L33<i16>;    COP: 2; R: 44; "c",
+    L33<i16>;    COP: 2; R: 44; c,
 
     /// Background color red component
-    RBK<u32>; COP: 2; R: 45; "c",
+    RBK<u32>; COP: 2; R: 45; c,
     /// Background color green component
-    GBK<u32>; COP: 2; R: 46; "c",
+    GBK<u32>; COP: 2; R: 46; c,
     /// Background color blue component
-    BBK<u32>; COP: 2; R: 47; "c",
+    BBK<u32>; COP: 2; R: 47; c,
 
     /// Light color matrix entries LR11 and LR12
-    LR11_12<u32>; COP: 2; R: 48; "c",
+    LR11_12<u32>; COP: 2; R: 48; c,
     /// Light color matrix entries LR13 and LR21
-    LR13_21<u32>; COP: 2; R: 49; "c",
+    LR13_21<u32>; COP: 2; R: 49; c,
     /// Light color matrix entries LR22 and LR23
-    LR22_23<u32>; COP: 2; R: 50; "c",
+    LR22_23<u32>; COP: 2; R: 50; c,
     /// Light color matrix entries LR31 and LR32
-    LR31_32<u32>; COP: 2; R: 51; "c",
+    LR31_32<u32>; COP: 2; R: 51; c,
     /// Light color matrix entry LR33
-    LR33<i16>;    COP: 2; R: 52; "c",
+    LR33<i16>;    COP: 2; R: 52; c,
 
     /// Far color red component
-    RFC<u32>; COP: 2; R: 53; "c",
+    RFC<u32>; COP: 2; R: 53; c,
     /// Far color green component
-    GFC<u32>; COP: 2; R: 54; "c",
+    GFC<u32>; COP: 2; R: 54; c,
     /// Far color blue component
-    BFC<u32>; COP: 2; R: 55; "c",
+    BFC<u32>; COP: 2; R: 55; c,
 
     /// Screen Offset and Distance X
-    OFX<u32>; COP: 2; R: 56; "c",
+    OFX<u32>; COP: 2; R: 56; c,
     /// Screen Offset and Distance Y
-    OFY<u32>; COP: 2; R: 57; "c",
+    OFY<u32>; COP: 2; R: 57; c,
     /// Projection plane distance
-    H<i16>;   COP: 2; R: 58; "c",
+    H<i16>;   COP: 2; R: 58; c,
 
     /// Depth queuing parameter A. (coefficient)
-    DQA<u32>; COP: 2; R: 59; "c",
+    DQA<u32>; COP: 2; R: 59; c,
     /// Depth queuing parameter B. (offset)
-    DQB<u32>; COP: 2; R: 60; "c",
+    DQB<u32>; COP: 2; R: 60; c,
 
     /// Z3 average scale factor (normally 1/3)
-    ZSF3<u32>; COP: 2; R: 61; "c",
+    ZSF3<u32>; COP: 2; R: 61; c,
     /// Z4 average scale factor (normally 1/4)
-    ZSF4<u32>; COP: 2; R: 62; "c",
+    ZSF4<u32>; COP: 2; R: 62; c,
 
     /// Error code status
-    FLAG<u32>; COP: 2; R: 63; "c",
+    FLAG<u32>; COP: 2; R: 63; c,
 }

--- a/psx/src/hw/gte.rs
+++ b/psx/src/hw/gte.rs
@@ -17,18 +17,47 @@ define_cop! {
     VXY2<u32>; COP: 2; R: 4,
     /// The 16-bit VZ2 vector
     VZ2<i16>;  COP: 2; R: 5,
-
+    /// RGB value
+    RGB<u32>; COP: 2; R: 6,
     /// Ordering table average Z value
     OTZ<u16>;  COP: 2; R: 7,
 
     /// Intermediate value 0
-    IR0<i32>; COP: 2; R: 8,
+    IR0<u32>; COP: 2; R: 8,
     /// Intermediate value 1
-    IR1<i32>; COP: 2; R: 9,
+    IR1<u32>; COP: 2; R: 9,
     /// Intermediate value 2
-    IR2<i32>; COP: 2; R: 10,
+    IR2<u32>; COP: 2; R: 10,
     /// Intermediate value 3
-    IR3<i32>; COP: 2; R: 11,
+    IR3<u32>; COP: 2; R: 11,
+
+    /// Screen XY coord FIFO 0
+    SXY0<u32>; COP: 2; R: 12,
+    /// Screen XY coord FIFO 1
+    SXY1<u32>; COP: 2; R: 13,
+    /// Screen XY coord FIFO 2
+    SXY2<u32>; COP: 2; R: 14,
+    /// Screen XY coord FIFO P
+    SXYP<u32>; COP: 2; R: 15,
+
+    /// Screen Z FIFO 0
+    SZ0<u16>; COP: 2; R: 16,
+    /// Screen Z FIFO 1
+    SZ1<u16>; COP: 2; R: 17,
+    /// Screen Z FIFO 2
+    SZ2<u16>; COP: 2; R: 18,
+    /// Screen Z FIFO 3
+    SZ3<u16>; COP: 2; R: 19,
+
+    /// Characteristic color FIFO 0
+    RGB0<u32>; COP: 2; R: 20,
+    /// Characteristic color FIFO 1
+    RGB1<u32>; COP: 2; R: 21,
+    /// Characteristic color FIFO 2
+    RGB2<u32>; COP: 2; R: 22,
+
+    /// Unused / Prohibited
+    RES1<u32>; COP: 2; R: 23,
 
     /// Scalar math accumulator
     MAC0<i32>; COP: 2; R: 24,
@@ -39,6 +68,11 @@ define_cop! {
     MAC2<i32>; COP: 2; R: 26,
     /// The third component of the vector math accumulator
     MAC3<i32>; COP: 2; R: 27,
+
+    /// IRGB
+    IRGB<u16>;  COP: 2; R: 28,
+    /// ORGB
+    ORGB<u16>;  COP: 2; R: 29,
 
     /// Leading zeros count source
     LZCS<u32>; COP: 2; R: 30,
@@ -57,6 +91,13 @@ define_cop! {
     /// Rotation matrix entry RT33
     RT33<i16>;    COP: 2; R: 36; "c",
 
+    /// Translation vector X
+    TRX<i32>; COP: 2; R: 37; "c",
+    /// Translation vector Y
+    TRY<i32>; COP: 2; R: 38; "c",
+    /// Translation vector Z
+    TRZ<i32>; COP: 2; R: 39; "c",
+
     /// Light matrix entries L11 and L12
     L11_12<u32>; COP: 2; R: 40; "c",
     /// Light matrix entries L13 and L21
@@ -67,6 +108,13 @@ define_cop! {
     L31_32<u32>; COP: 2; R: 43; "c",
     /// Light matrix entry L33
     L33<i16>;    COP: 2; R: 44; "c",
+
+    /// Background color red component
+    RBK<u32>; COP: 2; R: 45; "c",
+    /// Background color green component
+    GBK<u32>; COP: 2; R: 46; "c",
+    /// Background color blue component
+    BBK<u32>; COP: 2; R: 47; "c",
 
     /// Light color matrix entries LR11 and LR12
     LR11_12<u32>; COP: 2; R: 48; "c",
@@ -79,6 +127,12 @@ define_cop! {
     /// Light color matrix entry LR33
     LR33<i16>;    COP: 2; R: 52; "c",
 
+    /// Far color red component
+    RFC<u32>; COP: 2; R: 53; "c",
+    /// Far color green component
+    GFC<u32>; COP: 2; R: 54; "c",
+    /// Far color blue component
+    BFC<u32>; COP: 2; R: 55; "c",
 
     /// Screen Offset and Distance X
     OFX<u32>; COP: 2; R: 56; "c",
@@ -86,6 +140,16 @@ define_cop! {
     OFY<u32>; COP: 2; R: 57; "c",
     /// Projection plane distance
     H<i16>;   COP: 2; R: 58; "c",
+
+    /// Depth queuing parameter A. (coefficient)
+    DQA<u32>; COP: 2; R: 59; "c",
+    /// Depth queuing parameter B. (offset)
+    DQB<u32>; COP: 2; R: 60; "c",
+
+    /// Z3 average scale factor (normally 1/3)
+    ZSF3<u32>; COP: 2; R: 61; "c",
+    /// Z4 average scale factor (normally 1/4)
+    ZSF3<u32>; COP: 2; R: 62; "c",
 
     /// Error code status
     FLAG<u32>; COP: 2; R: 63; "c",

--- a/psx/src/hw/gte.rs
+++ b/psx/src/hw/gte.rs
@@ -36,39 +36,43 @@ define_cop! {
     /// Leading zeros count result
     LZCR<u32>; COP: 2; R: 31,
 
-    /*
-    TODO: LLVM doesn't support these coprocessor instructions yet (#7).
+    // TODO: LLVM doesn't support these coprocessor instructions yet (#7).
     /// Rotation matrix entries RT11 and RT12
     RT11_12<u32>; COP: 2; R: 32; "c",
+
     /// Rotation matrix entries RT13 and RT21
-    RT13_21<u32>; COP: 2; R: 33,
+    RT13_21<u32>; COP: 2; R: 33; "c",
     /// Rotation matrix entries RT22 and RT23
-    RT22_23<u32>; COP: 2; R: 34,
+    RT22_23<u32>; COP: 2; R: 34; "c",
     /// Rotation matrix entries RT31 and RT32
-    RT31_32<u32>; COP: 2; R: 35,
+    RT31_32<u32>; COP: 2; R: 35; "c",
     /// Rotation matrix entry RT33
-    RT33<i16>;    COP: 2; R: 36,
+    RT33<i16>;    COP: 2; R: 36; "c",
 
     /// Light matrix entries L11 and L12
-    L11_12<u32>; COP: 2; R: 40,
+    L11_12<u32>; COP: 2; R: 40; "c",
     /// Light matrix entries L13 and L21
-    L13_21<u32>; COP: 2; R: 41,
+    L13_21<u32>; COP: 2; R: 41; "c",
     /// Light matrix entries L22 and L23
-    L22_23<u32>; COP: 2; R: 42,
+    L22_23<u32>; COP: 2; R: 42; "c",
     /// Light matrix entries L31 and L32
-    L31_32<u32>; COP: 2; R: 43,
+    L31_32<u32>; COP: 2; R: 43; "c",
     /// Light matrix entry L33
-    L33<i16>;    COP: 2; R: 44,
+    L33<i16>;    COP: 2; R: 44; "c",
 
     /// Light color matrix entries LR11 and LR12
-    LR11_12<u32>; COP: 2; R: 48,
+    LR11_12<u32>; COP: 2; R: 48; "c",
     /// Light color matrix entries LR13 and LR21
-    LR13_21<u32>; COP: 2; R: 49,
+    LR13_21<u32>; COP: 2; R: 49; "c",
     /// Light color matrix entries LR22 and LR23
-    LR22_23<u32>; COP: 2; R: 50,
+    LR22_23<u32>; COP: 2; R: 50; "c",
     /// Light color matrix entries LR31 and LR32
-    LR31_32<u32>; COP: 2; R: 51,
+    LR31_32<u32>; COP: 2; R: 51; "c",
     /// Light color matrix entry LR33
-    LR33<i16>; COP: 2; R: 52,
-    */
+    LR33<i16>;    COP: 2; R: 52; "c",
+
+    /// Screen Offset and Distance X
+    OFX<u32>; COP: 2; R: 56; "c",
+    /// Screen Offset and Distance Y
+    OFY<u32>; COP: 2; R: 57; "c",
 }

--- a/psx/src/hw/gte.rs
+++ b/psx/src/hw/gte.rs
@@ -149,7 +149,7 @@ define_cop! {
     /// Z3 average scale factor (normally 1/3)
     ZSF3<u32>; COP: 2; R: 61; "c",
     /// Z4 average scale factor (normally 1/4)
-    ZSF3<u32>; COP: 2; R: 62; "c",
+    ZSF4<u32>; COP: 2; R: 62; "c",
 
     /// Error code status
     FLAG<u32>; COP: 2; R: 63; "c",

--- a/psx/src/hw/gte.rs
+++ b/psx/src/hw/gte.rs
@@ -71,8 +71,14 @@ define_cop! {
     /// Light color matrix entry LR33
     LR33<i16>;    COP: 2; R: 52; "c",
 
+
     /// Screen Offset and Distance X
     OFX<u32>; COP: 2; R: 56; "c",
     /// Screen Offset and Distance Y
     OFY<u32>; COP: 2; R: 57; "c",
+    /// Projection plane distance
+    H<i16>;   COP: 2; R: 58; "c",
+
+    /// Error code status
+    FLAG<u32>; COP: 2; R: 63; "c",
 }


### PR DESCRIPTION
closes #7 

This PR
* forms  `ctc1` and `cfc1` (recognised by LLVM), and LLVM missing `ctc2`, `cfc2` opcodes using `.long`s 
* retains the existing `CopRegister` macro format, with `m` or blank for Data, and `c` for Control
* retains the existing Cop register numbering from r0-r63
* uses LLVM for `mfc` and `mtc`,
* adds a delay `nop` after `mfc` to ensure the result value is available in subsequent reads which seems to be necessary for reliability. There may be more delays needed for some of the others, but I have only fixed the issues I noticed in my examples. Happy to take advice on how to handle this better if needed.

**Technical:**
I've used `$at` / `$1` as temporary storage since I couldn't see a way to use `in(reg)` or `out(reg)` directly in bitwise forming the opcode. The `addiu {}, $at, 0` copies the result back to the register Rust expects it for the `asm!` macro to set the variable. This frequently results in `addiu $at, $at, 0`, which does nothing. However, sometimes the Rust in/out register is _not_ `$at`, so it is needed. If anyone knows of a better way to handle this, please let me know!

Before merging this PR I should probably add in the full 64 GTE register definitions... **DONE!**

Co-Processor Op-code summary:
MIPS opcode | LLVM | PSX | this PR outputs | Description
-- | -- | -- | -- | --
`mfc0` | ✓ | ✓ | `mfc0` | Move from CoProc. 0
`mfc1` | ✓ | ❌ | `mfc1` | Move from Floating Point
`mfc2` | ✓ | ✓ | `mfc2` | Move from CoProc. 2
`mtc0` | ✓ | ✓ | `mtc0` | Move to CoProc. 0
`mtc1` | ✓ | ❌ | `mtc1` | Move to Floating Point
`mtc2` | ✓ | ✓ | `mtc2` | Move to CoProc. 2
`cfc1` | ✓ | ❌ | `.long` | Move Control Word from Floating Point
`cfc2` | ❌ | ✓ | `.long` | Move Control Word from CoProc. 2
`ctc1` | ✓ | ❌ | `.long` | Move Control Word to  Floating Point
`ctc2` | ❌ | ✓ | `.long` | Move Control Word to CoProc. 2
`cop2` | ❌ | ✓ | N/A (for later PR) | Coprocessor Operation to Coprocessor 2



**Testing**
I've got a separate project locally where I have tested:
* enabling and disabling the GTE 
* reading and writing GTE registers r0-r31 and r32-63 (once GTE is enabled)
* Just one GTE op `SQR` , `const SQR_OP: u32 = 0x0a00428;` which multiplies a vector by itself.

1) Super simple easy to verify example where `<1, 2, 3>` is squared to `<1, 4, 9>`:
<img width="1305" height="955" alt="Screenshot from 2025-11-19 22-50-14" src="https://github.com/user-attachments/assets/aa85247a-00e9-400a-864a-1c4622957b48" />

Simple, but performed by a previously inaccessible GTE :D

2) Forcing an overflow demonstrating that `FLAG` (r63) can be read and shows sensible error bits set based on the op ( 2 of the three registers have overflowed).
<img width="1305" height="955" alt="Screenshot from 2025-11-19 22-49-44" src="https://github.com/user-attachments/assets/357dca25-cf1e-4dda-bbfb-d48a4d4da330" />


**Not covered in this PR:**
Turns out LLVM does not support the `cop2` opcode either. This is used to send  GTE commands once the required registers have been set up.  I used this in my example to test:

```
    const SQR_OP: u32 = 0x0a00428;

    // SQR send cop2 
    unsafe {
        core::arch::asm! {
            "nop",
            ".long {} & 0x1ffffff | 37 << 25 # cop2",
            const SQR_OP,
            options(nomem, nostack)
        }
    }
```

I imagine adding this as a separate feature. I haven't really thought much about the full API needed, but to use the GTE properly the SDK needs Vectors, Matrices, and Colors of various sorts (with potentially different sizes depending on the context). And all the GTE op codes need to be defined.

Breaking all this up into separate manageable chunks seems sensible.