### PR TITLE
Add functions to help determine the region and NTSC/PAL mode of the console

### DIFF
--- a/psx/src/hw/gpu/gp1.rs
+++ b/psx/src/hw/gpu/gp1.rs
@@ -90,4 +90,15 @@ impl GP1 {
             .horizontal_range(disp_env.horizontal_range)
             .vertical_range(disp_env.vertical_range)
     }
+
+    /// Get the current video mode of the GPU.
+    pub fn get_video_mode(&mut self) -> VideoMode {
+        self.load();
+
+        if self.any_set(1 << 20) {
+            VideoMode::PAL
+        } else {
+            VideoMode::NTSC
+        }
+    }
 }

--- a/psx/src/sys/mod.rs
+++ b/psx/src/sys/mod.rs
@@ -49,6 +49,7 @@ enum SystemRegion {
     Unknown,
 }
 
+/// Returns the system's region.
 pub fn get_system_region() -> SystemRegion {
     const REGION_ID: *const u8 = 0xbfc7ff52 as _;
 

--- a/psx/src/sys/mod.rs
+++ b/psx/src/sys/mod.rs
@@ -51,7 +51,7 @@ enum SystemRegion {
 
 /// Returns the system's region.
 pub fn get_system_region() -> SystemRegion {
-    const REGION_ID: *const u8 = 0xbfc7ff52 as _;
+    const REGION_ID: *const u8 = 0xbfc7ff52u32 as _;
 
     // SAFETY: Sony BIOSes always have a character at this pointer denoting the
     // region of the console.

--- a/psx/src/sys/mod.rs
+++ b/psx/src/sys/mod.rs
@@ -42,10 +42,15 @@ pub fn get_system_version() -> &'static CStr {
     unsafe { CStr::from_ptr(version) }
 }
 
+/// System region
 pub enum SystemRegion {
+    /// Japan
     Japan,
+    /// North America
     NorthAmerica,
+    /// Europe
     Europe,
+    /// Unknown region
     Unknown,
 }
 

--- a/psx/src/sys/mod.rs
+++ b/psx/src/sys/mod.rs
@@ -42,7 +42,7 @@ pub fn get_system_version() -> &'static CStr {
     unsafe { CStr::from_ptr(version) }
 }
 
-enum SystemRegion {
+pub enum SystemRegion {
     Japan,
     NorthAmerica,
     Europe,
@@ -53,7 +53,7 @@ enum SystemRegion {
 pub fn get_system_region() -> SystemRegion {
     const REGION_ID: *const u8 = 0xbfc7ff52u32 as _;
 
-    // SAFETY: Sony BIOSes always have a character at this pointer denoting the
+    // SAFETY: Sony BIOSes usually have a character at this pointer denoting the
     // region of the console.
     //                                   pointer --
     //                                            v

--- a/psx/src/sys/mod.rs
+++ b/psx/src/sys/mod.rs
@@ -42,6 +42,33 @@ pub fn get_system_version() -> &'static CStr {
     unsafe { CStr::from_ptr(version) }
 }
 
+enum SystemRegion {
+    Japan,
+    NorthAmerica,
+    Europe,
+    Unknown,
+}
+
+pub fn get_system_region() -> SystemRegion {
+    const REGION_ID: *const u8 = 0xbfc7ff52 as _;
+
+    // SAFETY: Sony BIOSes always have a character at this pointer denoting the
+    // region of the console.
+    //                                   pointer --
+    //                                            v
+    // SCPH-5500: System ROM Version 3.0 09/09/96 J
+    // SCPH-5501: System ROM Version 3.0 11/18/96 A
+    // SCPH-5502: System ROM Version 3.0 01/06/97 E
+    // etc.
+    let region_char = char::from(unsafe { REGION_ID.read() });
+
+    match region_char {
+        'J' => SystemRegion::Japan,
+        'A' => SystemRegion::NorthAmerica,
+        'E' => SystemRegion::Europe,
+        _ => SystemRegion::Unknown,
+    }
+}
 /// Returns the kernel's date in BCD (e.g. 0x19951204).
 pub fn get_system_date() -> u32 {
     unsafe { kernel::psx_get_system_info(0) }


### PR DESCRIPTION
I added a couple functions in `sys` and the GP1 structure that helps determine the region and the original video mode (as initially set by the BIOS during the boot screen) of the GPU, given that the user hasn't yet overwritten the flag by initializing a Framebuffer or something.

This should help make universal PS1 applications possible