### PR TITLE
Add BIOS events, and an example using both graphics and gamepad

### DIFF
--- a/examples/gamepad/Cargo.toml
+++ b/examples/gamepad/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "gamepad"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+psx = { path = "../../psx" }

--- a/examples/gamepad/src/main.rs
+++ b/examples/gamepad/src/main.rs
@@ -5,7 +5,7 @@ use alloc::string::String;
 use psx::gpu::VideoMode;
 use psx::sys::event::{Event, Poll};
 use psx::sys::gamepad::Gamepad;
-use psx::{Framebuffer, dprintln};
+use psx::{Framebuffer, dprintln, println};
 
 psx::sys_heap!(500 KB);
 #[unsafe(no_mangle)]
@@ -14,7 +14,7 @@ fn main() {
     // the raw IRQ register (which is impossible to use alongside the BIOS'
     // gamepad handler without taking over the kernel). So we register a polling
     // BIOS event on the VBlank IRQ.
-    let vblank_event = Event::<Poll>::new(0xF2000003, 0x0002);
+    let vblank_event = Event::<Poll>::new(0xF2000003, 0x0002).unwrap();
 
     let buf0 = (0, 0);
     let buf1 = (0, 240);

--- a/examples/gamepad/src/main.rs
+++ b/examples/gamepad/src/main.rs
@@ -1,0 +1,65 @@
+#![no_std]
+#![no_main]
+
+use alloc::string::String;
+use psx::gpu::VideoMode;
+use psx::sys::event::{Event, Poll};
+use psx::sys::gamepad::Gamepad;
+use psx::{Framebuffer, dprintln};
+
+psx::sys_heap!(500 KB);
+#[unsafe(no_mangle)]
+fn main() {
+    // We don't use Framebuffer's functiion to wait for VBlank, as that relies on
+    // the raw IRQ register (which is impossible to use alongside the BIOS'
+    // gamepad handler without taking over the kernel). So we register a polling
+    // BIOS event on the VBlank IRQ.
+    let vblank_event = Event::<Poll>::new(0xF2000003, 0x0002);
+
+    let buf0 = (0, 0);
+    let buf1 = (0, 240);
+    let res = (320, 240);
+    let txt_offset = (0, 8);
+    let mut fb = Framebuffer::new(buf0, buf1, res, VideoMode::NTSC, None).unwrap();
+    let font = fb.load_default_font();
+    let mut txt = font.new_text_box(txt_offset, res);
+
+    // If we didn't have Gamepad here. we'd have to change the BIOS event to be a
+    // callback instead of a polling event (because the BIOS doesn't
+    // automatically acknowledge the IRQ at the end of the chain and requires
+    // one of the chain events to do so instead)
+    //
+    // Gamepad happens to auto-acknowledge VBlank IRQs, if change_clear_pad is set
+    // to 1
+    let mut gamepad = Gamepad::new();
+    loop {
+        let mut but_str = String::new();
+
+        for button in gamepad.poll_p1() {
+            but_str += match button {
+                psx::sys::gamepad::Button::Up => " U ",
+                psx::sys::gamepad::Button::Down => " D ",
+                psx::sys::gamepad::Button::Left => " L ",
+                psx::sys::gamepad::Button::Right => " R ",
+                psx::sys::gamepad::Button::Triangle => " /\\ ",
+                psx::sys::gamepad::Button::Cross => " X ",
+                psx::sys::gamepad::Button::Circle => " O ",
+                psx::sys::gamepad::Button::Square => " [] ",
+                psx::sys::gamepad::Button::L1 => " L1 ",
+                psx::sys::gamepad::Button::R1 => " R1 ",
+                psx::sys::gamepad::Button::L2 => " L2 ",
+                psx::sys::gamepad::Button::R2 => " R2 ",
+                psx::sys::gamepad::Button::L3 => " L3 ",
+                psx::sys::gamepad::Button::R3 => " R3 ",
+                psx::sys::gamepad::Button::Start => " S ",
+                psx::sys::gamepad::Button::Select => " s ",
+            };
+        }
+
+        txt.reset();
+        dprintln!(txt, "Buttons: {}", but_str);
+        fb.draw_sync();
+        vblank_event.wait();
+        fb.swap();
+    }
+}

--- a/psx/src/sys/event.rs
+++ b/psx/src/sys/event.rs
@@ -14,13 +14,16 @@ struct InternalEvent {
     _unused: [u8; 8],
 }
 
-/// Get a pointer to the Event Control Block belonging to a event handler.
-///
-/// This is not unsafe because all it does is calculate the pointer, it does not
-/// attempt to access the event itself.
-fn get_event_ptr(event: u32) -> *mut InternalEvent {
-    const SYS_EVCB: *const u32 = 0x120 as *const u32;
+const SYS_EVCB: *const u32 = 0x120 as _;
+const SYS_EVCB_SIZE: *const u32 = 0x124 as _;
 
+/// Get a pointer to the Event Control Block belonging to a event handler. This
+/// pointer is within the first 64 kilobytes of the system RAM.
+///
+/// SAFETY: You have to check that the handle is within the range of the EvCB
+/// table (by checking the size of the table against the handle), Otherwise, the
+/// resulting pointer may be invalid.
+unsafe fn get_event_ptr(event: u32) -> *mut InternalEvent {
     // SAFETY: This global variable should exist in all the Sony BIOSes.
     let evcb_ptr = unsafe { SYS_EVCB.read() } as *mut InternalEvent;
 
@@ -28,7 +31,7 @@ fn get_event_ptr(event: u32) -> *mut InternalEvent {
 }
 
 /// Status of the event.
-#[derive(PartialEq)]
+#[derive(Debug, PartialEq)]
 pub enum EventStatus {
     /// The event is free/unallocated
     Unallocated,
@@ -71,9 +74,12 @@ pub struct Event<MODE: EventMode> {
 impl<MODE: EventMode> Event<MODE> {
     /// Get the status of the event.
     pub fn status(&self) -> EventStatus {
-        // SAFETY: Since the kernel does not provide a function to get the status of the
+        // Since the kernel does not provide a function to get the status of the
         // event, we have to read the kernel's global variables to get it.
-        let evcb = get_event_ptr(self.handle);
+
+        // SAFETY: Once the event has been initialized by the BIOS, we can read the mode
+        // field without synchronization.
+        let evcb = unsafe { get_event_ptr(self.handle) };
 
         match unsafe { (*evcb).mode } {
             0 => EventStatus::Unallocated,
@@ -87,19 +93,28 @@ impl<MODE: EventMode> Event<MODE> {
 
 impl Event<Poll> {
     /// Create a new polling event.
-    pub fn new(class: u32, spec: u16) -> Event<Poll> {
+    ///
+    /// Returns an error if the handle it gets from the BIOS ends up being
+    /// invalid.
+    pub fn new(class: u32, spec: u16) -> Result<Event<Poll>, ()> {
         unsafe {
-            critical_section(|t| {
+            critical_section(|_| {
                 // The BIOS should never execute the callback, so we can set it to a null
                 // pointer
                 let handle = kernel::psx_open_event(class, spec, Poll::MODE_ID, 0x0 as _);
 
+                // Check if the handle is outside the EvCB table, and return an error if it is,
+                // since it most likely means an error occurred in the BIOS.
+                if (handle & 0xFFFF) * 0x1C > SYS_EVCB_SIZE.read() {
+                    return Err(());
+                }
+
                 kernel::psx_enable_event(handle);
 
-                Event {
+                Ok(Event {
                     handle,
                     _mode: PhantomData::<Poll>,
-                }
+                })
             })
         }
     }
@@ -124,17 +139,26 @@ impl Event<Poll> {
 
 impl Event<Callback> {
     /// Create a new callback event.
-    pub fn new(class: u32, spec: u16, callback: fn()) -> Event<Callback> {
+    ///
+    /// Returns an error if the handle it gets from the BIOS ends up being
+    /// invalid.
+    pub fn new(class: u32, spec: u16, callback: fn()) -> Result<Event<Callback>, ()> {
         unsafe {
             critical_section(|_| {
                 let handle = kernel::psx_open_event(class, spec, Callback::MODE_ID, callback as _);
 
+                // Check if the handle is outside the EvCB table, and return an error if it is,
+                // since it most likely means an error occurred in the BIOS.
+                if (handle & 0xFFFF) * 0x1C > SYS_EVCB_SIZE.read() {
+                    return Err(());
+                }
+
                 kernel::psx_enable_event(handle);
 
-                Event {
+                Ok(Event {
                     handle,
                     _mode: PhantomData::<Callback>,
-                }
+                })
             })
         }
     }

--- a/psx/src/sys/event.rs
+++ b/psx/src/sys/event.rs
@@ -10,7 +10,7 @@ struct InternalEvent {
     status: u32,
     spec: u32,
     mode: u32,
-    func_ptr: fn(),
+    func_ptr: extern "C" fn(),
     _unused: [u8; 8],
 }
 
@@ -142,7 +142,7 @@ impl Event<Callback> {
     ///
     /// Returns an error if the handle it gets from the BIOS ends up being
     /// invalid.
-    pub fn new(class: u32, spec: u16, callback: fn()) -> Result<Event<Callback>, ()> {
+    pub fn new(class: u32, spec: u16, callback: extern "C" fn()) -> Result<Event<Callback>, ()> {
         unsafe {
             critical_section(|_| {
                 let handle = kernel::psx_open_event(class, spec, Callback::MODE_ID, callback as _);

--- a/psx/src/sys/event.rs
+++ b/psx/src/sys/event.rs
@@ -1,0 +1,149 @@
+//! Module for BIOS events.
+
+use core::marker::PhantomData;
+
+use crate::sys::{critical_section, kernel};
+
+#[repr(C)]
+struct InternalEvent {
+    class: u32,
+    status: u32,
+    spec: u32,
+    mode: u32,
+    func_ptr: fn(),
+    _unused: [u8; 8],
+}
+
+/// Get a pointer to the Event Control Block belonging to a event handler.
+///
+/// This is not unsafe because all it does is calculate the pointer, it does not
+/// attempt to access the event itself.
+fn get_event_ptr(event: u32) -> *mut InternalEvent {
+    const SYS_EVCB: *const u32 = 0x120 as *const u32;
+
+    // SAFETY: This global variable should exist in all the Sony BIOSes.
+    let evcb_ptr = unsafe { SYS_EVCB.read() } as *mut InternalEvent;
+
+    return evcb_ptr.wrapping_add(event as usize & 0xFFFF);
+}
+
+/// Status of the event.
+#[derive(PartialEq)]
+pub enum EventStatus {
+    /// The event is free/unallocated
+    Unallocated,
+    /// The event is disabled
+    Disabled,
+    /// The event is enabled.
+    Enabled,
+    /// The event is enabled and ready.
+    Ready,
+    /// Unknown status
+    Unknown,
+}
+
+// Event modes
+trait EventMode {
+    const MODE_ID: u16;
+}
+
+/// An event in callback mode. When the event gets triggered, the BIOS will
+/// execute the associated callback function.
+pub struct Callback;
+
+/// An event in polling mode. When the event gets triggered, the BIOS will set
+/// the ready flag on the event.
+pub struct Poll;
+
+impl EventMode for Callback {
+    const MODE_ID: u16 = 0x1000;
+}
+impl EventMode for Poll {
+    const MODE_ID: u16 = 0x2000;
+}
+
+/// An event handle
+pub struct Event<MODE: EventMode> {
+    handle: u32,
+    _mode: PhantomData<MODE>,
+}
+
+impl<MODE: EventMode> Event<MODE> {
+    /// Get the status of the event.
+    pub fn status(&self) -> EventStatus {
+        // SAFETY: Since the kernel does not provide a function to get the status of the
+        // event, we have to read the kernel's global variables to get it.
+        let evcb = get_event_ptr(self.handle);
+
+        match unsafe { (*evcb).mode } {
+            0 => EventStatus::Unallocated,
+            0x1000 => EventStatus::Disabled,
+            0x2000 => EventStatus::Enabled,
+            0x4000 => EventStatus::Ready,
+            _ => EventStatus::Unknown,
+        }
+    }
+}
+
+impl Event<Poll> {
+    /// Create a new polling event.
+    pub fn new(class: u32, spec: u16) -> Event<Poll> {
+        unsafe {
+            critical_section(|t| {
+                // The BIOS should never execute the callback, so we can set it to a null
+                // pointer
+                let handle = kernel::psx_open_event(class, spec, Poll::MODE_ID, 0x0 as _);
+
+                kernel::psx_enable_event(handle);
+
+                Event {
+                    handle,
+                    _mode: PhantomData::<Poll>,
+                }
+            })
+        }
+    }
+
+    /// Test if the event has been triggered by the kernel. If it has, then
+    /// it'll return `true`
+    pub fn test(&self) -> bool {
+        unsafe { kernel::psx_test_event(self.handle) }
+    }
+
+    /// Spin until the event becomes ready.
+    ///
+    /// NOTE: This will return immediately if the event is disabled. Thus, you
+    /// should check the status of the event (with `.status()`) to see if
+    /// it's disabled beforehand.
+    pub fn wait(&self) {
+        unsafe {
+            kernel::psx_wait_event(self.handle);
+        }
+    }
+}
+
+impl Event<Callback> {
+    /// Create a new callback event.
+    pub fn new(class: u32, spec: u16, callback: fn()) -> Event<Callback> {
+        unsafe {
+            critical_section(|_| {
+                let handle = kernel::psx_open_event(class, spec, Callback::MODE_ID, callback as _);
+
+                kernel::psx_enable_event(handle);
+
+                Event {
+                    handle,
+                    _mode: PhantomData::<Callback>,
+                }
+            })
+        }
+    }
+}
+
+impl<MODE: EventMode> Drop for Event<MODE> {
+    fn drop(&mut self) {
+        unsafe {
+            kernel::psx_close_event(self.handle);
+        }
+    }
+}

--- a/psx/src/sys/kernel.rs
+++ b/psx/src/sys/kernel.rs
@@ -118,6 +118,8 @@ extern "C" {
     pub fn psx_start_pad();
     /// Calls BIOS function [B(14h)](http://problemkaputt.de/psx-spx.htm#biosfunctionsummary)
     pub fn psx_stop_pad();
+    /// Calls BIOS function [B(17h)](http://problemkaputt.de/psx-spx.htm#biosfunctionsummary)
+    pub fn psx_return_from_exception();
     /// Calls BIOS function [B(18h)](http://problemkaputt.de/psx-spx.htm#biosfunctionsummary)
     pub fn psx_set_default_exit_from_exception();
     /// Calls BIOS function [B(20h)](http://problemkaputt.de/psx-spx.htm#biosfunctionsummary)
@@ -381,6 +383,10 @@ pub const START_PAD_TY: u8 = 0xB0;
 pub const STOP_PAD_NUM: u8 = 0x14;
 /// The BIOS function type for stop_pad
 pub const STOP_PAD_TY: u8 = 0xB0;
+/// The BIOS function number for return_from_exception
+pub const RETURN_FROM_EXCEPTION_NUM: u8 = 0x17;
+/// The BIOS function type for return_from_exception
+pub const RETURN_FROM_EXCEPTION_TY: u8 = 0xB0;
 /// The BIOS function number for set_default_exit_from_exception
 pub const SET_DEFAULT_EXIT_FROM_EXCEPTION_NUM: u8 = 0x18;
 /// The BIOS function type for set_default_exit_from_exception

--- a/psx/src/sys/mod.rs
+++ b/psx/src/sys/mod.rs
@@ -5,6 +5,7 @@
 use crate::CriticalSection;
 use core::ffi::CStr;
 
+pub mod event;
 pub mod fs;
 pub mod gamepad;
 pub mod heap;

--- a/psx/src/sys/trampoline.s
+++ b/psx/src/sys/trampoline.s
@@ -393,6 +393,13 @@ psx_stop_pad:
     jr $8
     li $9, 0x14
 
+.section .text.bios.psx_return_from_exception
+.globl psx_return_from_exception
+psx_return_from_exception:
+    la $8, 0xB0
+    jr $8
+    li $9, 0x17
+
 .section .text.bios.psx_set_default_exit_from_exception
 .globl psx_set_default_exit_from_exception
 psx_set_default_exit_from_exception:

--- a/scripts/bios.txt
+++ b/scripts/bios.txt
@@ -196,7 +196,10 @@ B(14h) stop_pad();
 
 //B(15h) OutdatedPadInitAndStart(type,button_dest,unused,unused)
 //B(16h) OutdatedPadGetButtons()
-//B(17h) ReturnFromException()
+
+// Return from an exception handler.
+B(17h) return_from_exception();
+
 B(18h) set_default_exit_from_exception();
 //B(19h) SetCustomExitFromException(addr)
 


### PR DESCRIPTION
This example showcases how to use BIOS events to wait for VBlanks, instead of relying on the IRQ register directly, due to interference with BIOS' gamepad code.

Fixes #28 (by not using wait_vblank)