### PR TITLE
Add controller rumble/vibration support

### DIFF
--- a/examples/gamepad/src/main.rs
+++ b/examples/gamepad/src/main.rs
@@ -32,8 +32,16 @@ fn main() {
     // Gamepad happens to auto-acknowledge VBlank IRQs, if change_clear_pad is set
     // to 1
     let mut gamepad = Gamepad::new();
+    let mut vibration = false;
+    let mut start_last_frame = false;
+    let mut start_this_frame = false;
+
     loop {
         let mut but_str = String::new();
+        let buttons = gamepad.poll_p1();
+
+        // Check if Start is held this frame.
+        start_this_frame = buttons.pressed(psx::sys::gamepad::Button::Start);
 
         for button in gamepad.poll_p1() {
             but_str += match button {
@@ -58,8 +66,26 @@ fn main() {
 
         txt.reset();
         dprintln!(txt, "Buttons: {}", but_str);
+
+        // This is just to stop the program from spamming 1-frame vibrations (which is
+        // kinda like a half-vibration).
+        if start_last_frame ^ start_this_frame {
+            vibration = !vibration;
+        }
+
+        if vibration {
+            dprintln!(txt, "Release Start to stop vibrating!");
+        } else {
+            dprintln!(txt, "Hold Start to start vibrating!");
+        }
+
         fb.draw_sync();
+        gamepad.vibration_p1(vibration);
         vblank_event.wait();
+
+        start_last_frame = start_this_frame;
+        start_this_frame = false;
+
         fb.swap();
     }
 }

--- a/psx/src/sys/gamepad.rs
+++ b/psx/src/sys/gamepad.rs
@@ -1,8 +1,11 @@
 //! Gamepad polling operations
 use crate::sys::kernel;
+use crate::sys::patch;
+use crate::sys::patch::PadOutputFunction;
 use core::marker::PhantomData;
 use core::mem::size_of;
 use core::mem::MaybeUninit;
+use core::ptr::null;
 use core::ptr::read_volatile;
 
 // TODO: this is off by a factor of two, but I should double check whether the
@@ -21,7 +24,17 @@ pub struct Gamepad<'a> {
     buf1: *mut u16,
     buf2: *mut u16,
     _buf: PhantomData<&'a mut [u32; BUFFER_SIZE]>,
+    pad_output: PadOutputFunction,
+    vibration_p1: bool,
+    vibration_p2: bool,
 }
+
+/// Data to be sent to the controller to activate the vibration motors.
+///
+/// The first byte is set to 0xFF because the BIOS checks if it should use the
+/// output buffer by accessing the first byte of the buffer and checking if it's
+/// zero (and then checking if the buffer pointer is NULL, yeah).
+static VIBRATION_ON_BUFFER: [u8; 3] = [0xFF, 0x40, 0x01];
 
 /// The reading from polling the gamepad buttons
 pub struct Buttons {
@@ -169,10 +182,14 @@ impl<'a> Gamepad<'a> {
         buf1.cast::<u32>().add(1).write_volatile(0x8080_8080);
         kernel::psx_start_pad();
         kernel::psx_change_clear_pad(1);
+
         Self {
             buf1,
             buf2,
             _buf: PhantomData,
+            pad_output: patch::send_pad_output(),
+            vibration_p1: false,
+            vibration_p2: false,
         }
     }
 
@@ -216,6 +233,40 @@ impl<'a> Gamepad<'a> {
     /// cannot be elided.
     pub fn poll_lstick_p2(&mut self) -> JoyStick {
         unsafe { JoyStick(read_volatile(self.buf2.add(3))) }
+    }
+
+    fn apply_vibration(&mut self) {
+        let p1_buffer: *const u8 = if self.vibration_p1 {
+            VIBRATION_ON_BUFFER.as_ptr()
+        } else {
+            null()
+        };
+
+        let p2_buffer: *const u8 = if self.vibration_p2 {
+            VIBRATION_ON_BUFFER.as_ptr()
+        } else {
+            null()
+        };
+
+        // The size arguments aren't used at all in the BIOS code, so they can be set to
+        // whatever.
+        (self.pad_output)(
+            p1_buffer,
+            VIBRATION_ON_BUFFER.len(),
+            p2_buffer,
+            VIBRATION_ON_BUFFER.len(),
+        );
+    }
+    /// Turn on or off the vibration motors in player 1's controller.
+    pub fn vibration_p1(&mut self, enable: bool) {
+        self.vibration_p1 = enable;
+        self.apply_vibration();
+    }
+
+    /// Turn on or off the vibration motors in player 2's controller.
+    pub fn vibration_p2(&mut self, enable: bool) {
+        self.vibration_p2 = enable;
+        self.apply_vibration();
     }
 }
 

--- a/psx/src/sys/kernel.rs
+++ b/psx/src/sys/kernel.rs
@@ -146,6 +146,8 @@ extern "C" {
     pub fn psx_get_last_error() -> u32;
     /// Calls BIOS function [B(55h)](http://problemkaputt.de/psx-spx.htm#biosfunctionsummary)
     pub fn psx_get_last_file_error(fd: i8) -> u32;
+    /// Calls BIOS function [B(57h)](http://problemkaputt.de/psx-spx.htm#biosfunctionsummary)
+    pub fn psx_get_b0_table() -> u32;
     /// Calls BIOS function [B(5Bh)](http://problemkaputt.de/psx-spx.htm#biosfunctionsummary)
     pub fn psx_change_clear_pad(int: u32);
     /// Calls BIOS function [C(0Ah)](http://problemkaputt.de/psx-spx.htm#biosfunctionsummary)
@@ -439,6 +441,10 @@ pub const GET_LAST_ERROR_TY: u8 = 0xB0;
 pub const GET_LAST_FILE_ERROR_NUM: u8 = 0x55;
 /// The BIOS function type for get_last_file_error
 pub const GET_LAST_FILE_ERROR_TY: u8 = 0xB0;
+/// The BIOS function number for get_b0_table
+pub const GET_B0_TABLE_NUM: u8 = 0x57;
+/// The BIOS function type for get_b0_table
+pub const GET_B0_TABLE_TY: u8 = 0xB0;
 /// The BIOS function number for change_clear_pad
 pub const CHANGE_CLEAR_PAD_NUM: u8 = 0x5B;
 /// The BIOS function type for change_clear_pad

--- a/psx/src/sys/mod.rs
+++ b/psx/src/sys/mod.rs
@@ -10,6 +10,7 @@ pub mod fs;
 pub mod gamepad;
 pub mod heap;
 pub mod kernel;
+pub mod patch;
 pub mod rng;
 pub mod tty;
 

--- a/psx/src/sys/mod.rs
+++ b/psx/src/sys/mod.rs
@@ -10,7 +10,7 @@ pub mod fs;
 pub mod gamepad;
 pub mod heap;
 pub mod kernel;
-pub mod patch;
+pub(crate) mod patch;
 pub mod rng;
 pub mod tty;
 

--- a/psx/src/sys/patch.rs
+++ b/psx/src/sys/patch.rs
@@ -36,7 +36,6 @@ pub(crate) unsafe fn send_pad_output() -> PadOutputFunction {
     // Get the pointer to the pad output function.
     let pad_output_func: PadOutputFunction =
         core::mem::transmute(unsafe { chgclearpad_func.byte_add(PAD_OUTPUT_OFFSET) });
-    println!("Pad output function: {:#x?}", pad_output_func);
 
     // Patch a couple parts of the code related to the `readPad` function.
     for code in NEW_CODE {

--- a/psx/src/sys/patch.rs
+++ b/psx/src/sys/patch.rs
@@ -1,0 +1,49 @@
+//! Unsafe patches to the BIOS
+//!
+//! This module contains functions that directly patch the BIOS code (in the
+//! first 64 kilobytes of RAM), to work around issues in Sony's implementation.
+
+use crate::{println, sys::kernel};
+
+pub(crate) type PadOutputFunction = extern "C" fn(*const u8, usize, *const u8, usize);
+
+/// Fetch the internal BIOS function responsible for setting the pad output
+/// buffers (also known as `setPadOutputData`), and patches the `readPad`
+/// function to disable the 0-1 data clipping
+pub(crate) unsafe fn send_pad_output() -> PadOutputFunction {
+    // This code was inspired by the games that employed this BIOS patch, which
+    // includes Resident Evil 2 and Lemmings.
+    // https://psx-spx.consoledev.net/kernelbios/#patch_optional_pad_output
+    static NEW_CODE: [u32; 4] = [
+        0x00551024, // and  r2,r21
+        0x00000000, // nop
+        0x00000000, // nop
+        0x00000000, // nop
+    ];
+
+    static PAD_OUTPUT_OFFSET: usize = 0x7A0;
+    static READPAD_1_OFFSET: usize = 0x3D8;
+    static READPAD_2_OFFSET: usize = 0x4DC;
+
+    // Fetch the B syscall table from the kernel.
+    let mut b0_table: *const u32 = kernel::psx_get_b0_table() as _;
+    b0_table = b0_table.add(0x5B);
+
+    // Code for the ChangeClearPAD function. We're using this as a starting point
+    // for the code offsets.
+    let mut chgclearpad_func: *mut u32 = unsafe { b0_table.read() } as _;
+
+    // Get the pointer to the pad output function.
+    let pad_output_func: PadOutputFunction =
+        core::mem::transmute(unsafe { chgclearpad_func.byte_add(PAD_OUTPUT_OFFSET) });
+    println!("Pad output function: {:#x?}", pad_output_func);
+
+    // Patch a couple parts of the code related to the `readPad` function.
+    for code in NEW_CODE {
+        chgclearpad_func.byte_add(READPAD_1_OFFSET).write(code);
+        chgclearpad_func.byte_add(READPAD_2_OFFSET).write(code);
+        chgclearpad_func = chgclearpad_func.byte_add(4);
+    }
+
+    pad_output_func
+}

--- a/psx/src/sys/patch.rs
+++ b/psx/src/sys/patch.rs
@@ -3,8 +3,34 @@
 //! This module contains functions that directly patch the BIOS code (in the
 //! first 64 kilobytes of RAM), to work around issues in Sony's implementation.
 
-use crate::{println, sys::kernel};
+use crate::sys::kernel;
 
+/// This function sets the pad output buffers to the specified pointers. Note
+/// that the size (usize parameters) are never used in the BIOS code, so you
+/// don't have to care about them.
+///
+/// The first byte of the buffer must be a non-zero value, or else the BIOS will
+/// ignore it
+///
+/// The BIOS will output the data within the buffer (from the second byte of the
+/// buffer), after it has issued a Read command to the controller.
+///
+/// # Example
+///
+/// | Buffer               | What the BIOS sends to the controller |
+/// |----------------------|---------------------------------------|
+/// | `[0xFF, 0xDE, 0xAD]` | `0x01 0x42 0x00 0xDE 0xAD`            |
+///
+/// # Parameters
+/// 1. Pointer to a buffer containing bytes to output to the player
+/// 1 controller after Read command.
+///
+/// 2. Size of the buffer (player 1/ignored).
+///
+/// 3. Pointer to a buffer containing bytes to output to the player
+/// 2 controller after Read command.
+///
+/// 4. Size of the buffer (player 2/ignored).
 pub(crate) type PadOutputFunction = extern "C" fn(*const u8, usize, *const u8, usize);
 
 /// Fetch the internal BIOS function responsible for setting the pad output

--- a/psx/src/sys/trampoline.s
+++ b/psx/src/sys/trampoline.s
@@ -491,6 +491,13 @@ psx_get_last_file_error:
     jr $8
     li $9, 0x55
 
+.section .text.bios.psx_get_b0_table
+.globl psx_get_b0_table
+psx_get_b0_table:
+    la $8, 0xB0
+    jr $8
+    li $9, 0x57
+
 .section .text.bios.psx_change_clear_pad
 .globl psx_change_clear_pad
 psx_change_clear_pad:


### PR DESCRIPTION
This PR adds vibration support to the gamepad code. This does get deep into the BIOS to obtain the function for setting the pad output data (and also patches the BIOS code to get rid of the boolean clipping), so I don't know how safe this is really.

If you wanna test this in an emulator, you can try in DuckStation. (as PCSX-Redux and Mednafen didn't work for me, most likely they don't emulate vibrations)