### PR TITLE
Add raw CD-ROM access functions via BIOS

### DIFF
--- a/psx/src/sys/cdrom.rs
+++ b/psx/src/sys/cdrom.rs
@@ -1,0 +1,37 @@
+//! Raw CD-ROM access (via the BIOS functions).
+
+use crate::sys::kernel;
+
+enum Error {
+    /// The output buffer is not divisible by the size of a CD-ROM Mode 1 sector
+    /// (2048 bytes)
+    BufferNotDivisible,
+    /// An error occured during a BIOS function call. The value is the error
+    /// code obtained from the BIOS.
+    BIOSError(i32),
+}
+
+/// Reads Mode 1 sectors from the CD, starting from the sector at `start`.
+///
+/// The buffer must be exactly large enough to fit as many sectors to read from
+/// the CD. (2 sectors: buffer of 4096 bytes, e.g.)
+///
+/// Returns the amount of sectors that were read from the CD.
+pub fn read_sectors(start: i32, buffer: &mut [u8]) -> Result<usize, Error> {
+    // Check if the size of the buffer is divisible by the CD sector size.
+    if buffer.len() & 0x7FF != 0 {
+        return Err(Error::BufferNotDivisible);
+    }
+
+    // SAFETY: We've checked the size of the output buffer to ensure that there
+    // won't be an overflow when the BIOS reads sectors from the CD into the
+    // buffer.
+    let res = unsafe {
+        kernel::psx_cd_read_sector((buffer.len() >> 11) as i32, start, buffer.as_mut_ptr())
+    };
+
+    match res {
+        0..=i32::MAX => Ok(res as usize),
+        i32::MIN..=-1 => Err(Error::BIOSError(res)),
+    }
+}

--- a/psx/src/sys/fs.rs
+++ b/psx/src/sys/fs.rs
@@ -401,12 +401,12 @@ impl File<MemCard> {
 
 impl File<CDROM> {
     /// Attempts to fetch the first LBN of a file in the CD.
-    pub fn first_lbn(path: &str) -> Result<usize, Error<CDROM>> {
+    pub fn first_lbn(path: &CStr) -> Result<usize, Error<CDROM>> {
         // This is just here to make sure the filesystem is initialized before we
         // continue.
         OpenOptions::<CDROM>::new();
 
-        path.as_cstr(|path| unsafe {
+        unsafe {
             let res = kernel::psx_cd_get_lbn(path.as_ptr());
 
             match res {
@@ -414,7 +414,7 @@ impl File<CDROM> {
                 -1 => Err(Error::Unresolved),
                 0..=i32::MAX => Ok(res as usize),
             }
-        })
+        }
     }
 }
 

--- a/psx/src/sys/fs.rs
+++ b/psx/src/sys/fs.rs
@@ -399,6 +399,25 @@ impl File<MemCard> {
     }
 }
 
+impl File<CDROM> {
+    /// Attempts to fetch the first LBN of a file in the CD.
+    pub fn first_lbn(path: &str) -> Result<usize, Error<CDROM>> {
+        // This is just here to make sure the filesystem is initialized before we
+        // continue.
+        OpenOptions::<CDROM>::new();
+
+        path.as_cstr(|path| unsafe {
+            let res = kernel::psx_cd_get_lbn(path.as_ptr());
+
+            match res {
+                i32::MIN..=-2 => Err(Error::Resolved(ErrorKind::UnknownError)),
+                -1 => Err(Error::Unresolved),
+                0..=i32::MAX => Ok(res as usize),
+            }
+        })
+    }
+}
+
 impl<T: FileTy> Drop for File<T> {
     fn drop(&mut self) {
         let _res = unsafe { kernel::psx_file_close(self.fd) };

--- a/psx/src/sys/kernel.rs
+++ b/psx/src/sys/kernel.rs
@@ -80,6 +80,8 @@ extern "C" {
     pub fn psx_warm_boot() -> !;
     /// Calls BIOS function [A(A4h)](http://problemkaputt.de/psx-spx.htm#biosfunctionsummary)
     pub fn psx_cd_get_lbn(filename: *const i8) -> i32;
+    /// Calls BIOS function [A(A5h)](http://problemkaputt.de/psx-spx.htm#biosfunctionsummary)
+    pub fn psx_cd_read_sector(count: i32, sector: i32, buffer: *mut u8) -> i32;
     /// Calls BIOS function [A(A6h)](http://problemkaputt.de/psx-spx.htm#biosfunctionsummary)
     pub fn psx_cd_get_status(dst: *mut u32);
     /// Calls BIOS function [A(B4h)](http://problemkaputt.de/psx-spx.htm#biosfunctionsummary)
@@ -307,6 +309,10 @@ pub const WARM_BOOT_TY: u8 = 0xA0;
 pub const CD_GET_LBN_NUM: u8 = 0xA4;
 /// The BIOS function type for cd_get_lbn
 pub const CD_GET_LBN_TY: u8 = 0xA0;
+/// The BIOS function number for cd_read_sector
+pub const CD_READ_SECTOR_NUM: u8 = 0xA5;
+/// The BIOS function type for cd_read_sector
+pub const CD_READ_SECTOR_TY: u8 = 0xA0;
 /// The BIOS function number for cd_get_status
 pub const CD_GET_STATUS_NUM: u8 = 0xA6;
 /// The BIOS function type for cd_get_status

--- a/psx/src/sys/mod.rs
+++ b/psx/src/sys/mod.rs
@@ -5,6 +5,7 @@
 use crate::CriticalSection;
 use core::ffi::CStr;
 
+pub mod cdrom;
 pub mod event;
 pub mod fs;
 pub mod gamepad;

--- a/psx/src/sys/trampoline.s
+++ b/psx/src/sys/trampoline.s
@@ -260,6 +260,13 @@ psx_cd_get_lbn:
     jr $8
     li $9, 0xA4
 
+.section .text.bios.psx_cd_read_sector
+.globl psx_cd_read_sector
+psx_cd_read_sector:
+    la $8, 0xA0
+    jr $8
+    li $9, 0xA5
+
 .section .text.bios.psx_cd_get_status
 .globl psx_cd_get_status
 psx_cd_get_status:

--- a/scripts/bios.txt
+++ b/scripts/bios.txt
@@ -153,7 +153,7 @@ A(A0h) warm_boot() -> !;
 //A(A2h) enqueuecdintr()  ;with prio=0 (fixed);
 //A(A3h) dequeuecdintr()  ;does NOT work due to SysDeqIntRP bug;
 A(A4h) cd_get_lbn(filename: *const i8) -> i32;
-//A(A5h) cdreadsector(count,sector,buffer);
+A(A5h) cd_read_sector(count: i32, sector: i32, buffer: *mut u8) -> i32;
 A(A6h) cd_get_status(dst: *mut u32);
 //A(A7h) bu_callback_okay();
 //A(A8h) bu_callback_err_write();


### PR DESCRIPTION
Added functions to read raw Mode 1 sectors from the CD, and get the first LBN of a file in the CD.

These use BIOS functions instead of interacting with the CD-ROM drive directly